### PR TITLE
make Reset SoC a spin box

### DIFF
--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -58,6 +58,9 @@ class Daly(Battery):
                 self.read_battery_code(ser)
                 result = self.read_status_data(ser)
                 self.read_soc_data(ser)
+                self.reset_soc = (
+                    self.soc
+                )  # set to meaningful value as preset for the GUI
 
         except Exception as err:
             logger.error(f"Unexpected {err=}, {type(err)=}")
@@ -603,9 +606,14 @@ class Daly(Battery):
             return False
 
     def reset_soc_callback(self, path, value):
-        self.reset_soc = 0
-        if value == 1:
-            self.soc_to_set = 100
+        if value is None:
+            return False
+
+        if value < 0 or value > 100:
+            return False
+
+        self.reset_soc = value
+        self.soc_to_set = value
         return True
 
     def write_soc_and_datetime(self, ser):

--- a/etc/dbus-serialbattery/install-qml.sh
+++ b/etc/dbus-serialbattery/install-qml.sh
@@ -77,6 +77,7 @@ if (( $venusVersionNumber < $versionNumber )); then
     fileList="$qmlDir/PageBattery.qml"
     fileList+=" $qmlDir/PageBatteryCellVoltages.qml"
     fileList+=" $qmlDir/PageBatteryParameters.qml"
+    fileList+=" $qmlDir/PageBatterySettings.qml"
     fileList+=" $qmlDir/PageBatterySetup.qml"
     fileList+=" $qmlDir/PageLynxIonIo.qml"
     for file in $fileList ; do

--- a/etc/dbus-serialbattery/qml/PageBatterySettings.qml
+++ b/etc/dbus-serialbattery/qml/PageBatterySettings.qml
@@ -57,16 +57,17 @@ MbPage {
                         show: valid
                 }
 
-                MbItemOptions {
-                        description: qsTr("Reset SOC to 100%")
-                        bind: Utils.path(root.bindPrefix, "/Settings/ResetSoc")
-                        text: qsTr("Press to reset")
-                        show: valid
-                        possibleValues: [
-                                MbOption { description: qsTr("Cancel"); value: 0 },
-                                MbOption { description: qsTr("Reset"); value: 1 }
-                        ]
+        
+                MbSpinBox {
+                        description: "Reset SoC to"
+                        item.bind: Utils.path(bindPrefix, "/Settings/ResetSoc")
+                        item.min: 0
+                        item.max: 100
+                        item.step: 1
                 }
+
+
+
 
         }
 }


### PR DESCRIPTION
Change GUI widget to spin box 0-100. will be preset with the current SOC.
fix missing line in install-qml.sh for the settings page