### PR TITLE
Fix daly readsentence

### DIFF
--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -573,7 +573,7 @@ class Daly(Battery):
         ser.write(cmd)
 
         reply = self.read_sentence(ser, self.command_set_soc)
-        if reply[0] != 1:
+        if reply is False or reply[0] != 1:
             logger.error("write soc failed")
         return True
 


### PR DESCRIPTION
small fix, I found by the way.
A bad answer on writing SOC would crash the driver.
(never had it while developing with uart, but it fails very often with RS485/on a device with older FW)