### PR TITLE
Fix daly rs485 write timing (write SOC problem)

### DIFF
--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -548,6 +548,10 @@ class Daly(Battery):
         if self.soc_to_set is None:
             return False
 
+        # wait shortly, else the Daly is not ready and throws a lot of no reply errors
+        # if you see a lot of errors, try to increase in steps of 0.005
+        sleep(0.020)
+
         cmd = bytearray(13)
         now = datetime.now()
 
@@ -615,6 +619,10 @@ class Daly(Battery):
             and self.trigger_force_disable_discharge is None
         ):
             return False
+
+        # wait shortly, else the Daly is not ready and throws a lot of no reply errors
+        # if you see a lot of errors, try to increase in steps of 0.005
+        sleep(0.020)
 
         cmd = bytearray(self.command_base)
 


### PR DESCRIPTION
with the new cables I was able to sniff the rs485 traffic and found that in some cases (writing SOC to the bms) no data was actually written. So this was not the dalys fault but some behaviour of the RS485 converter (driver switching, I guess). It didn't happen with UART, just with RS485. 

Finally I added the same sleep that you already used for the request_data function, that you implemented to help another user who was having a lot read errors. This seems consistent as I remember he had a rs485 cable.