### PR TITLE
fix meaningless time to go values

### DIFF
--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -612,7 +612,7 @@ class DbusHelper:
                                 )
                             )
                         )
-                        if self.battery.current
+                        if self.battery.current and abs(self.battery.current) > 0.1
                         else None
                     )
 


### PR DESCRIPTION
Interesting that there were no complaints to far. I've seen it quite some times that my battery gets full and lingers around with almost no current. So the time to go showed strange values then