### PR TITLE
Fixing JK BMS black version.

### DIFF
--- a/etc/dbus-serialbattery/bms/jkbms_can.py
+++ b/etc/dbus-serialbattery/bms/jkbms_can.py
@@ -57,7 +57,7 @@ class Jkbms_Can(Battery):
         BATT_STAT: [0x02F4, 0x02F5],
         CELL_VOLT: [0x04F4, 0x04F5],
         CELL_TEMP: [0x05F4, 0x05F5],
-        ALM_INFO: [0x07F4, 0x07F5]
+        ALM_INFO: [0x07F4, 0x07F5],
     }
 
     def test_connection(self):

--- a/etc/dbus-serialbattery/bms/jkbms_can.py
+++ b/etc/dbus-serialbattery/bms/jkbms_can.py
@@ -54,10 +54,10 @@ class Jkbms_Can(Battery):
     # B2A... Silver is using 0x0XF5
     # See https://github.com/Louisvdw/dbus-serialbattery/issues/950
     CAN_FRAMES = {
-        BATT_STAT: [0x02F4,0x02F5],
-        CELL_VOLT: [0x04F4,0x04F5],
-        CELL_TEMP: [0x05F4,0x05F5],
-        ALM_INFO: [0x07F4,0x07F5]
+        BATT_STAT: [0x02F4, 0x02F5],
+        CELL_VOLT: [0x04F4, 0x04F5],
+        CELL_TEMP: [0x05F4, 0x05F5],
+        ALM_INFO: [0x07F4, 0x07F5]
     }
 
     def test_connection(self):

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -12,6 +12,10 @@ LOGGING = INFO
 MAX_BATTERY_CHARGE_CURRENT    = 50.0
 MAX_BATTERY_DISCHARGE_CURRENT = 60.0
 
+; ----------Cell count ------------
+; Predefine cell count for Jkbms_can
+; Should be autodetected if not set
+JKBMS_CAN_CELL_COUNT = 1
 
 ; --------- Cell Voltages ---------
 ; Description:

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -386,11 +386,10 @@ BATTERY_CAPACITY = 50
 INVERT_CURRENT_MEASUREMENT = 1
 
 ; -- JK (Jikong) settings
-; Cell count
-; Predefine cell count for Jkbms_can
-; The cell count should be normally auto-detected by identifying the highest cell number,
-; but this process is sometimes slow what may cause that cells are not updated on VenusOS.
-; Try this workaround if you have experience problems with cell voltage.
+; Predefines cell count for Jkbms_can
+; The cell count should be auto-detected by identifying the highest cell number,
+; but this process may be sometimes slow what could cause that cells voltage is not not 
+; updated in VenusOS. Try this workaround if you experience problems with cell voltage.
 JKBMS_CAN_CELL_COUNT = 1
 
 ; -- ESC GreenMeter and Lipro device settings

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -12,11 +12,6 @@ LOGGING = INFO
 MAX_BATTERY_CHARGE_CURRENT    = 50.0
 MAX_BATTERY_DISCHARGE_CURRENT = 60.0
 
-; ----------Cell count ------------
-; Predefine cell count for Jkbms_can
-; Should be autodetected if not set
-JKBMS_CAN_CELL_COUNT = 1
-
 ; --------- Cell Voltages ---------
 ; Description:
 ;     Cell min/max voltages which are used to calculate the min/max battery voltage
@@ -389,6 +384,14 @@ SOC_LOW_ALARM   = 10
 BATTERY_CAPACITY = 50
 ; Invert Battery Current. Default non-inverted. Set to -1 to invert
 INVERT_CURRENT_MEASUREMENT = 1
+
+; -- JK (Jikong) settings
+; Cell count
+; Predefine cell count for Jkbms_can
+; The cell count should be normally auto-detected by identifying the highest cell number,
+; but this process is sometimes slow what may cause that cells are not updated on VenusOS.
+; Try this workaround if you have experience problems with cell voltage.
+JKBMS_CAN_CELL_COUNT = 1
 
 ; -- ESC GreenMeter and Lipro device settings
 GREENMETER_ADDRESS  = 1

--- a/etc/dbus-serialbattery/dbushelper.py
+++ b/etc/dbus-serialbattery/dbushelper.py
@@ -1021,6 +1021,12 @@ class DbusHelper:
                     3,
                 )
             except Exception:
+                exception_type, exception_object, exception_traceback = sys.exc_info()
+                file = exception_traceback.tb_frame.f_code.co_filename
+                line = exception_traceback.tb_lineno
+                logger.error(
+                    f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}"
+                )
                 pass
 
         # Update TimeToGo and/or TimeToSoC

--- a/etc/dbus-serialbattery/reinstall-local.sh
+++ b/etc/dbus-serialbattery/reinstall-local.sh
@@ -199,7 +199,8 @@ bluetooth_length=${#bms_array[@]}
 # echo $bluetooth_length
 
 # stop all dbus-blebattery services, if at least one exists
-if [ -d "/service/dbus-blebattery.0" ]; then
+if ls /service/dbus-blebattery.* 1> /dev/null 2>&1; then
+    echo "Killing old BLE battery services..."
     svc -t /service/dbus-blebattery.*
 
     # always remove existing blebattery services to cleanup
@@ -386,7 +387,8 @@ can_lenght=${#can_array[@]}
 # echo $can_lenght
 
 # stop all dbus-canbattery services, if at least one exists
-if [ -d "/service/dbus-canbattery.0" ]; then
+if ls /service/dbus-canbattery.* 1> /dev/null 2>&1; then
+    echo "Killing old CAN battery services..."
     svc -t /service/dbus-canbattery.*
 
     # always remove existing canbattery services to cleanup
@@ -395,10 +397,7 @@ if [ -d "/service/dbus-canbattery.0" ]; then
     # kill all canbattery processes that remain
     pkill -f "supervise dbus-canbattery.*"
     pkill -f "multilog .* /var/log/dbus-canbattery.*"
-    pkill -f "python .*/dbus-serialbattery.py .*_Ble"
-
-    # kill opened bluetoothctl processes
-    pkill -f "^bluetoothctl "
+    pkill -f "python .*/dbus-serialbattery.py can.*"
 fi
 
 

--- a/etc/dbus-serialbattery/utils.py
+++ b/etc/dbus-serialbattery/utils.py
@@ -53,6 +53,7 @@ else:
 
 # save config values to constants
 
+
 # --------- Battery Current limits ---------
 MAX_BATTERY_CHARGE_CURRENT = float(config["DEFAULT"]["MAX_BATTERY_CHARGE_CURRENT"])
 MAX_BATTERY_DISCHARGE_CURRENT = float(
@@ -249,6 +250,9 @@ SOC_LOW_ALARM = float(config["DEFAULT"]["SOC_LOW_ALARM"])
 # -- Daly settings
 BATTERY_CAPACITY = float(config["DEFAULT"]["BATTERY_CAPACITY"])
 INVERT_CURRENT_MEASUREMENT = int(config["DEFAULT"]["INVERT_CURRENT_MEASUREMENT"])
+
+# -- JK BMS settings
+JKBMS_CAN_CELL_COUNT = int(config["DEFAULT"]["JKBMS_CAN_CELL_COUNT"])
 
 # -- ESC GreenMeter and Lipro device settings
 GREENMETER_ADDRESS = int(config["DEFAULT"]["GREENMETER_ADDRESS"])


### PR DESCRIPTION
My previouse change related to https://github.com/Louisvdw/dbus-serialbattery/issues/950 for JK bms can broke older "Black" JK bms devices. See fix in `jkbms_can.py`.

JK BMS cells are updating very slowly via can bus and cell count can be increased few times before all detected. This causes exception in `dbushelpre.py` at line `self._dbusservice[cellpath % (str(i + 1))] = voltage`. In the end the cell voltage values were missing and not updated in VenusOS. So I added option to preset cell count for JK CAN  `JKBMS_CAN_CELL_COUNT` which resolves the issue. Original logic is kept so the parameter is optional and not necessary if it works without. 

Last change in this PR fixes the reinstall shell script. It may happen that user has can2, but not can0 used by dbus-serialbattery. The original detection for can0 didn't work in such case. I included same fix for BLE even it may not be necessary.