### PR TITLE
Fix restarting GUI service

### DIFF
--- a/etc/dbus-serialbattery/install-qml.sh
+++ b/etc/dbus-serialbattery/install-qml.sh
@@ -121,11 +121,9 @@ fi
 
 # if files changed, restart gui
 if [ $filesChanged -gt 0 ]; then
-    # stop gui
-    svc -d /service/gui
-    # sleep 1 sec
-    sleep 1
-    # start gui
-    svc -u /service/gui
+    service_path="/service/start-gui"
+    if [ -d $service_path ] && [ -f "$service_path/supervise/status" ]; then
+        svc -d -u "$service_path"
+    fi
     echo "New QML files were installed and the GUI was restarted."
 fi

--- a/etc/dbus-serialbattery/install-qml.sh
+++ b/etc/dbus-serialbattery/install-qml.sh
@@ -121,9 +121,10 @@ fi
 
 # if files changed, restart gui
 if [ $filesChanged -gt 0 ]; then
+    echo "New QML files were installed"
     service_path="/service/start-gui"
     if [ -d $service_path ] && [ -f "$service_path/supervise/status" ]; then
         svc -d -u "$service_path"
+        echo "The GUI was restarted"
     fi
-    echo "New QML files were installed and the GUI was restarted."
 fi

--- a/etc/dbus-serialbattery/restore-gui.sh
+++ b/etc/dbus-serialbattery/restore-gui.sh
@@ -24,9 +24,7 @@ if [ -f /opt/victronenergy/gui/qml/PageLynxIonIo.qml.backup ]; then
     echo "PageLynxIonIo.qml was restored."
 fi
 
-#stop gui
-svc -d /service/gui
-#sleep 1 sec
-sleep 1
-#start gui
-svc -u /service/gui
+service_path="/service/start-gui"
+if [ -d $service_path ] && [ -f "$service_path/supervise/status" ]; then
+    svc -d -u "$service_path"
+fi


### PR DESCRIPTION
I updated to Venus v3.33 and noticed following error in `/var/log/boot`:
```
Mon Jun 17 20:28:43 2024: svc: warning: unable to chdir to /service/gui: file does not exist
Mon Jun 17 20:28:44 2024: svc: warning: unable to chdir to /service/gui: file does not exist
Mon Jun 17 20:28:44 2024: New QML files were installed and the GUI was restarted.
```
It seems `/service/gui` was replaced by `/service/start-gui`. Not sure when this was done? It is not something specific to v3.33.

Is it also necessary to restart the GUI process in `install-qml.sh`? The battery interface looks fine without it.
Maybe only necessary for `restore-gui.sh`?