### PR TITLE
Moved some bluetooth specific code from each implementation to a common place

### DIFF
--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -19,7 +19,7 @@ class Jkbms_Ble(Battery):
     def __init__(self, port, baud, address):
         # add "ble_" to the port name, since only numbers are not valid
         super(Jkbms_Ble, self).__init__(
-            "ble_" + address.replace(":", "").lower(), baud, address
+            port, baud, address
         )
         self.address = address
         self.type = self.BATTERYTYPE

--- a/etc/dbus-serialbattery/bms/jkbms_ble.py
+++ b/etc/dbus-serialbattery/bms/jkbms_ble.py
@@ -17,7 +17,6 @@ class Jkbms_Ble(Battery):
     resetting = False
 
     def __init__(self, port, baud, address):
-        # add "ble_" to the port name, since only numbers are not valid
         super(Jkbms_Ble, self).__init__(
             port, baud, address
         )

--- a/etc/dbus-serialbattery/bms/lltjbd_ble.py
+++ b/etc/dbus-serialbattery/bms/lltjbd_ble.py
@@ -25,9 +25,8 @@ class LltJbd_Ble(LltJbd):
     BATTERYTYPE = "LltJbd_Ble"
 
     def __init__(self, port: Optional[str], baud: Optional[int], address: str):
-        # add "ble_" to the port name, since only numbers are not valid
         super(LltJbd_Ble, self).__init__(
-            "ble_" + address.replace(":", "").lower(), -1, address
+            port, -1, address
         )
 
         self.address = address

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -176,23 +176,24 @@ def main():
         This prevent problems when using the driver only with a serial connection
         """
 
-        if len(sys.argv) <= 2
+        if len(sys.argv) <= 2:
             logger.error("missing bluetooth address")
-        ble_address = sys.argv[2]
+        else:
+            ble_address = sys.argv[2]
         
-        if port == "Jkbms_Ble":
-            # noqa: F401 --> ignore flake "imported but unused" error
-            from bms.jkbms_ble import Jkbms_Ble  # noqa: F401
+            if port == "Jkbms_Ble":
+                # noqa: F401 --> ignore flake "imported but unused" error
+                from bms.jkbms_ble import Jkbms_Ble  # noqa: F401
 
-        if port == "LltJbd_Ble":
-            # noqa: F401 --> ignore flake "imported but unused" error
-            from bms.lltjbd_ble import LltJbd_Ble  # noqa: F401
+            if port == "LltJbd_Ble":
+                # noqa: F401 --> ignore flake "imported but unused" error
+                from bms.lltjbd_ble import LltJbd_Ble  # noqa: F401
 
-        class_ = eval(port)
-        testbms = class_(port + "_" + ble_address.replace(":", "").lower(), 9600, ble_address)
-        if testbms.test_connection():
-            logger.info("Connection established to " + testbms.__class__.__name__)
-            battery = testbms
+            class_ = eval(port)
+            testbms = class_("ble_" + ble_address.replace(":", "").lower(), 9600, ble_address)
+            if testbms.test_connection():
+                logger.info("Connection established to " + testbms.__class__.__name__)
+                battery = testbms
 
     elif port.startswith("can"):
         """

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -170,11 +170,16 @@ def main():
     # else the error throw a lot of timeouts
     sleep(16)
 
-    if port.endswith("_Ble") and len(sys.argv) > 2:
+    if port.endswith("_Ble"):
         """
         Import ble classes only, if it's a ble port, else the driver won't start due to missing python modules
         This prevent problems when using the driver only with a serial connection
         """
+
+        if len(sys.argv) <= 2
+            logger.error("missing bluetooth address")
+        ble_address = sys.argv[2]
+        
         if port == "Jkbms_Ble":
             # noqa: F401 --> ignore flake "imported but unused" error
             from bms.jkbms_ble import Jkbms_Ble  # noqa: F401
@@ -184,7 +189,7 @@ def main():
             from bms.lltjbd_ble import LltJbd_Ble  # noqa: F401
 
         class_ = eval(port)
-        testbms = class_("", 9600, sys.argv[2])
+        testbms = class_(port + "_" + ble_address.replace(":", "").lower(), 9600, ble_address)
         if testbms.test_connection():
             logger.info("Connection established to " + testbms.__class__.__name__)
             battery = testbms


### PR DESCRIPTION
The same code was duplicated making things harder to read. This patch removes the duplicated code.
It also fixes en issue that could occur when a Bluetooth BMS was configured to be used but no address was given.