### PR TITLE
Fixes for multi BMS on single USB-adapter

### DIFF
--- a/etc/dbus-serialbattery/bms/seplosv3.py
+++ b/etc/dbus-serialbattery/bms/seplosv3.py
@@ -42,14 +42,17 @@ class Seplosv3(Battery):
         return struct.unpack("<h", packval)[0]
 
     def get_modbus(self, slaveaddress=0) -> minimalmodbus.Instrument:
-        if self.mbdev is not None and slaveaddress == self.slaveaddress:
-            return self.mbdev
-
         # hack to allow communication to the Seplos BMS using minimodbus which uses slaveaddress 0 as broadcast
+        # Make sure we re-set these values whenever we want to access the modbus. Just in case of a
+        # multi-device setup with different addresses and subsequent tries on a different address modified it.
         if slaveaddress == 0:
             minimalmodbus._SLAVEADDRESS_BROADCAST = 0xF0
         else:
             minimalmodbus._SLAVEADDRESS_BROADCAST = 0
+        
+        if self.mbdev is not None and slaveaddress == self.slaveaddress:
+            return self.mbdev
+
 
         mbdev = minimalmodbus.Instrument(
             self.port,

--- a/etc/dbus-serialbattery/bms/seplosv3.py
+++ b/etc/dbus-serialbattery/bms/seplosv3.py
@@ -49,10 +49,9 @@ class Seplosv3(Battery):
             minimalmodbus._SLAVEADDRESS_BROADCAST = 0xF0
         else:
             minimalmodbus._SLAVEADDRESS_BROADCAST = 0
-        
+
         if self.mbdev is not None and slaveaddress == self.slaveaddress:
             return self.mbdev
-
 
         mbdev = minimalmodbus.Instrument(
             self.port,

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -270,7 +270,22 @@ def main():
         # check if MODBUS_ADDRESSES is not empty
         if utils.MODBUS_ADDRESSES:
             for address in utils.MODBUS_ADDRESSES:
-                battery[address] = get_battery(port, address)
+                checkbatt = get_battery(port, address)
+                if checkbatt is not None:
+                    battery[address] = checkbatt
+                    logger.info(
+                        "Successful battery connection at "
+                        + port
+                        + " and this Modbus address "
+                        + str(address)
+                    )
+                else:
+                    logger.warning(
+                        "No battery connection at "
+                        + port
+                        + " and this Modbus address "
+                        + str(address)
+                    )
         # use default address
         else:
             battery[0] = get_battery(port)
@@ -281,15 +296,6 @@ def main():
     for key_address in battery:
         if battery[key_address] is not None:
             battery_found = True
-        elif key_address != 0:
-            # remove item from battery dict so that only the found batteries are used
-            del battery[key_address]
-            logger.warning(
-                "No battery connection at "
-                + port
-                + " and this Modbus address "
-                + str(key_address)
-            )
 
     if not battery_found:
         logger.error(


### PR DESCRIPTION
Hi,

When running multiple BMS types over various addresses, I ran into an error whereby an unhandled exception is thrown: "RuntimeError: dictionary changed size during iteration". The cause for this exception was deleting 'None' values from the battery[] array in dbus-serialbattery.py. This causes the instance to crash and restart.

This happens when you specify multiple BMS to query, and specify multiple MODBUS_ADDRESSES in config.ini. If you have multiple BMS and various addresses, it is inevitable that a BMS/address combination that doesn't exist gets queried.
The main loop iterates all BMS for each address and stores an instance or None for that address. After that, the None-values get cleaned from the array while it's iterating it.

Note that the way this is built still only allows you to use unique addresses amongst all types of BMS in your configuration. Even if you use multiple USB-adapters, or have multiple systems whereby duplicate addressing isn't conflicting between the systems. It probably still deserves attention. Perhaps a more efficient way is to specify the addresses for each type of BMS in config.ini? 

I worked around it by no longer adding all get_battery() attempts, but only when they're not None to begin with.

A second issue I came across has to do with the Seplosv3 BMS. Also, when used with multiple addresses, the system calls test_connection() on multiple instances with different addresses. The Seplosv3 class sets "minimalmodbus._SLAVEADDRESS_BROADCAST" based on the address of that instance. But only once at init. Subsequent tries with other addresses change the value, but it does not get re-set for the actual working instance when it wasn't the last one that succeeded.

I fixed that by re-setting the value every time self.get_modbus() gets called.

Thanks for the work you guys put in! :)

Kind regards,