### PR TITLE
Parallel Daly BMS

### DIFF
--- a/etc/dbus-serialbattery/bms/daly.py
+++ b/etc/dbus-serialbattery/bms/daly.py
@@ -813,7 +813,7 @@ class Daly(Battery):
 
         # logger.info(f"reply: {bytearray_to_string(reply)}")  # debug
 
-        if id != 1 or length != 8 or cmd != expected_reply[0]:
+        if (63 + id) != self.address[0] or length != 8 or cmd != expected_reply[0]:
             logger.debug(
                 f"read_sentence {bytearray_to_string(expected_reply)}: wrong header"
             )

--- a/etc/dbus-serialbattery/config.default.ini
+++ b/etc/dbus-serialbattery/config.default.ini
@@ -369,6 +369,9 @@ TIME_TO_SOC_INC_FROM = False
 ;     Daly, Daren485, Ecs, EG4_Lifepower, EG4_LL, HeltecModbus, HLPdataBMS4S, Jkbms, Jkbms_pb, LltJbd, Renogy, Seplos, Seplosv3
 ; Available BMS, but disabled by default (just enter one or more below and it will be enabled):
 ;     ANT, MNB, Sinowealth
+; Note: When using multiple Daly in parallel, via RS-485 bus or multiple "UART" ports, specify all the BMS board addresses via MODBUS_ADDRESSES (0x40 = board 0, 0x41 = board 1, ... 0x4F = board 16)
+; BMSTYPE = Daly
+; MODBUS_ADDRESSES = 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F
 BMS_TYPE =
 
 ; Exclude this serial devices from the driver startup

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -43,7 +43,10 @@ if "Sinowealth" in utils.BMS_TYPE:
     from bms.sinowealth import Sinowealth
 
 supported_bms_types = [
-    # {"bms": Daly, "baud": 9600},          # For multiple boards (1-16) in parallel, specify board addresses (0x40-0x4F) via MODBUS_ADDRESSES in config.ini (see "BMSTYPE = Daly" in config.default.ini), and comment out the following 2 Daly lines if desired.
+    # For multiple boards (1-16) in parallel, specify board addresses (0x40-0x4F) via MODBUS_ADDRESSES in config.ini
+    #     (see "BMSTYPE = Daly" in config.default.ini), and enable the following line... optionally disable
+    #     the 2 Daly lines following.
+    # {"bms": Daly, "baud": 9600},
     {"bms": Daly, "baud": 9600, "address": b"\x40"},
     {"bms": Daly, "baud": 9600, "address": b"\x80"},
     {"bms": Daren485, "baud": 19200, "address": b"\x01"},

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -43,7 +43,7 @@ if "Sinowealth" in utils.BMS_TYPE:
     from bms.sinowealth import Sinowealth
 
 supported_bms_types = [
-    #{"bms": Daly, "baud": 9600},          # For multiple boards (1-16) in parallel, specify board addresses (0x40-0x4F) via MODBUS_ADDRESSES in config.ini (see "BMSTYPE = Daly" in config.default.ini), and comment out the following 2 Daly lines if desired.
+    # {"bms": Daly, "baud": 9600},          # For multiple boards (1-16) in parallel, specify board addresses (0x40-0x4F) via MODBUS_ADDRESSES in config.ini (see "BMSTYPE = Daly" in config.default.ini), and comment out the following 2 Daly lines if desired.
     {"bms": Daly, "baud": 9600, "address": b"\x40"},
     {"bms": Daly, "baud": 9600, "address": b"\x80"},
     {"bms": Daren485, "baud": 19200, "address": b"\x01"},

--- a/etc/dbus-serialbattery/dbus-serialbattery.py
+++ b/etc/dbus-serialbattery/dbus-serialbattery.py
@@ -43,6 +43,7 @@ if "Sinowealth" in utils.BMS_TYPE:
     from bms.sinowealth import Sinowealth
 
 supported_bms_types = [
+    #{"bms": Daly, "baud": 9600},          # For multiple boards (1-16) in parallel, specify board addresses (0x40-0x4F) via MODBUS_ADDRESSES in config.ini (see "BMSTYPE = Daly" in config.default.ini), and comment out the following 2 Daly lines if desired.
     {"bms": Daly, "baud": 9600, "address": b"\x40"},
     {"bms": Daly, "baud": 9600, "address": b"\x80"},
     {"bms": Daren485, "baud": 19200, "address": b"\x01"},


### PR DESCRIPTION
Adjust read_sentence in daly.py to allow BMS configured for parallel (different board number assigned).
Provide sample entry for supported_bms_types in dbus-serialbattery.py ... this may not be necessary.
Provide sample config in config.default.ini to use MODBUS_ADDRESSES to set addresses of Daly board numbers.

This change works with all BMS (max 16) on RS485 bus with a single serial port adapter or individual UART adapters to each BMS.