### PR TITLE
use sum of cell voltages instead of 1 decimal accuracy value from CAN

### DIFF
--- a/dbus-serialbattery/bms/jkbms_can.py
+++ b/dbus-serialbattery/bms/jkbms_can.py
@@ -182,6 +182,7 @@ class Jkbms_Can(Battery):
                     self.cells.insert(i, Cell(False))
                     self.cell_count = len(self.cells)
                 self.cells[i].voltage = cell_voltage
+        self.voltage = self.get_cell_voltage_sum()
 
     def read_jkbms_can(self):
         # reset errors after timeout
@@ -197,9 +198,9 @@ class Jkbms_Can(Battery):
 
             # Frame is send every 20ms
             if normalized_arbitration_id in self.CAN_FRAMES[self.BATT_STAT]:
-                voltage = unpack_from("<H", bytes([data[0], data[1]]))[0]
-                self.voltage = voltage / 10
-
+                # skip voltage due to 0.1V accuracy only and use update_cell_voltages() instead for calculation
+                # voltage = unpack_from("<H", bytes([data[0], data[1]]))[0]
+                # self.voltage = voltage / 10                      
                 current = unpack_from("<H", bytes([data[2], data[3]]))[0]
                 self.current = (current / 10) - 400
 

--- a/dbus-serialbattery/bms/jkbms_can.py
+++ b/dbus-serialbattery/bms/jkbms_can.py
@@ -198,9 +198,9 @@ class Jkbms_Can(Battery):
 
             # Frame is send every 20ms
             if normalized_arbitration_id in self.CAN_FRAMES[self.BATT_STAT]:
-                # skip voltage due to 0.1V accuracy only and use update_cell_voltages() instead for calculation
+                # skip voltage due to 0.1V accuracy only and use update_cell_voltages() instead
                 # voltage = unpack_from("<H", bytes([data[0], data[1]]))[0]
-                # self.voltage = voltage / 10                      
+                # self.voltage = voltage / 10
                 current = unpack_from("<H", bytes([data[2], data[3]]))[0]
                 self.current = (current / 10) - 400
 


### PR DESCRIPTION
the voltage value from the CAN frame for the whole battery has only 1 decimal accuracy, so use the sum of the cell voltages to get 2 decimal accuracy