### PR TITLE
CAN utils - Expire messages from cache

### DIFF
--- a/dbus-serialbattery/bms/jkbms_can.py
+++ b/dbus-serialbattery/bms/jkbms_can.py
@@ -186,7 +186,7 @@ class Jkbms_Can(Battery):
 
     def read_jkbms_can(self):
         # reset errors after timeout
-        if ((time() - self.last_error_time) > 120.0) and self.error_active is True:
+        if ((time() - self.last_error_time) > 15.0) and self.error_active is True:
             self.error_active = False
             self.reset_protection_bits()
 


### PR DESCRIPTION
Modified the code in utils_can that you can specify arbitration IDs wich are removed from cache after timeout with notification in the log.

This is neccessary for JK BMS who sent ALM_INFO 0x07F4 and BMSERR_INFO 0x18F328F4 only when alarm ocours. 

This will solve that the driver will stay with an alarm in an endless loop.

!!! Remember that the timer in last_error_time in jkbms_can.py is set to 120.0s. So if you want to a shorter time, reduce it.!!!


Its been tested now for 2 weeks without any issue. So it works stable.

