### PR TITLE
All received CAN frames will only be cached for 5 seconds

### DIFF
--- a/dbus-serialbattery/bms/jkbms_can.py
+++ b/dbus-serialbattery/bms/jkbms_can.py
@@ -70,9 +70,6 @@ class Jkbms_Can(Battery):
         BMS_CHG_INFO: [0x1806E5F4],
     }
 
-    # Frames that are only send when an error occurs, but not reset after the error is gone
-    FRAMES_TO_CLEAR = CAN_FRAMES[ALM_INFO] + CAN_FRAMES[BMSERR_INFO]
-
     def connection_name(self) -> str:
         return f"CAN socketcan:{self.port}" + (f"__{self.device_address}" if self.device_address != 0 else "")
 
@@ -192,7 +189,6 @@ class Jkbms_Can(Battery):
         # timeout is 300 seconds, to prevent notification spam
         if ((int(time()) - self.last_error_time) > 300) and self.error_active is True:
             self.error_active = False
-            self.can_transport_interface.can_message_cache_clear_old_entries(self.FRAMES_TO_CLEAR)
             self.reset_protection_bits()
 
         # check if all needed data is available

--- a/dbus-serialbattery/dbus-serialbattery.py
+++ b/dbus-serialbattery/dbus-serialbattery.py
@@ -387,7 +387,6 @@ def main():
 
         can_transport_interface = CanTransportInterface()
         can_transport_interface.can_message_cache_callback = can_thread.get_message_cache
-        can_transport_interface.can_message_cache_clear_old_entries = can_thread.clear_old_cache_entries
         can_transport_interface.can_bus = can_thread.can_bus
         logger.debug("Wait shortly to make sure that all needed data is in the cache")
         # Slowest message cycle transmission is every 1 second, wait a bit more for the first time to fetch all needed data (only jk bms)

--- a/dbus-serialbattery/utils_can.py
+++ b/dbus-serialbattery/utils_can.py
@@ -12,7 +12,6 @@ class CanTransportInterface:
     """
 
     can_message_cache_callback: callable = None
-    can_message_cache_clear_old_entries: callable = None
     can_bus = None
 
 
@@ -34,7 +33,8 @@ class CanReceiverThread(threading.Thread):
         self.bustype = bustype
         self.message_cache = {}  # cache can frames here
         self.cache_lock = threading.Lock()  # lock for thread safety
-        self.last_received_time = {}  # track last received time for each arbitration ID
+        self._last_received_time = {}  # track last received time for each arbitration ID
+        self._last_cache_clean_time = 0 # last time the cached was cleaned (deleted too old values)
         CanReceiverThread._instances[(channel, bustype)] = self
         self.daemon = True
         self._running = True  # flag to control the running state
@@ -42,6 +42,7 @@ class CanReceiverThread(threading.Thread):
         self.can_initialised = threading.Event()
         self._link_status_cache = {"timestamp": 0, "result": None}
         self.initial_interface_state = self.get_link_status()
+        self.current_time = int(time())
 
     @classmethod
     def get_instance(cls, channel, bustype) -> "CanReceiverThread":
@@ -78,13 +79,17 @@ class CanReceiverThread(threading.Thread):
         self.can_initialised.set()
 
         while self._running:
+            self.current_time = int(time())
+
             link_status = self.get_link_status()
+            self.clear_old_cache_entries()
+
             if link_status:
                 try:
                     message = self.can_bus.recv(timeout=1.0)  # wait for max 1 second to receive message
 
                     if message is not None:
-                        last_message_time_stamp = int(time())
+                        last_message_time_stamp = self.current_time
                         with self.cache_lock:
 
                             # daly hack: cell voltage messages are sent with same id, so use frame id additionally as offset for cmd byte
@@ -95,7 +100,7 @@ class CanReceiverThread(threading.Thread):
 
                             # cache data with arbitration id as key
                             self.message_cache[message.arbitration_id] = message.data
-                            self.last_received_time[message.arbitration_id] = int(time())  # update last received time
+                            self.last_received_time[message.arbitration_id] = last_message_time_stamp  # update last received time
 
                         logger.debug(f"[{self.channel}] Received: ID={hex(message.arbitration_id)}, Daten={message.data}")
 
@@ -110,7 +115,7 @@ class CanReceiverThread(threading.Thread):
                 self.last_received_time = {}
                 sleep(1)
 
-            if int(time()) - last_message_time_stamp > 2 and self.message_cache:
+            if self.current_time - last_message_time_stamp > 2 and self.message_cache:
                 logger.debug(f"CAN Bus {self.channel} has not received any messages in the last 2 seconds")
                 self.message_cache = {}
                 self.last_received_time = {}
@@ -118,23 +123,22 @@ class CanReceiverThread(threading.Thread):
 
         self.stop()
 
-    # Clear cache entries for defined arbitration IDs if they have not been received for 10 seconds.
-    def clear_old_cache_entries(self, arb_id_list: list = []) -> None:
+    # Clear cache entries for defined arbitration IDs if they have not been received for 5 seconds.
+    def clear_old_cache_entries(self) -> None:
         """
-        Clear cache entries for defined arbitration IDs if they have not been received for 10 seconds.
+        Clear cache entries for defined arbitration IDs if they have not been received for 5 seconds.
 
-        :param arb_id_list: list of arbitration IDs to clear cache for
         :return: None
         """
-        if not arb_id_list:
+        # do this once 1 second to reduce load
+        if self._last_cache_clean_time + 1 > self.current_time:
             return
 
-        current_time = time()
         with self.cache_lock:
-            for arb_id in list(self.message_cache.keys()):
-                if arb_id in arb_id_list and (current_time - self.last_received_time.get(arb_id, 0) > 10):
+            for arb_id in list(self._last_received_time.keys()):
+                if self.current_time - self._last_received_time[arb_id] > 5:
                     del self.message_cache[arb_id]
-                    del self.last_received_time[arb_id]
+                    del self._last_received_time[arb_id]
                     logger.debug(f"[{self.channel}] Cleared cache for arbitration ID {hex(arb_id)} due to timeout")
 
     def stop(self) -> None:
@@ -174,16 +178,15 @@ class CanReceiverThread(threading.Thread):
         :return: True if interface is up, False otherwise
         """
 
-        current_time = time()
         # Check if cached result is still valid
-        if self._link_status_cache["timestamp"] + 1 > current_time:
+        if self._link_status_cache["timestamp"] + 1 > self.current_time:
             return self._link_status_cache["result"]
 
         result = subprocess.run(["ip", "link", "show", self.channel], capture_output=True, text=True, check=True)
         status = "UP" in result.stdout
 
         # Update the cache
-        self._link_status_cache["timestamp"] = current_time
+        self._link_status_cache["timestamp"] = self.current_time
         self._link_status_cache["result"] = status
 
         return status

--- a/dbus-serialbattery/utils_can.py
+++ b/dbus-serialbattery/utils_can.py
@@ -135,7 +135,7 @@ class CanReceiverThread(threading.Thread):
             return
 
         # update time
-        _last_cache_clean_time = self.current_time
+        self._last_cache_clean_time = self.current_time
 
         with self.cache_lock:
             for arb_id in list(self._last_received_time.keys()):

--- a/dbus-serialbattery/utils_can.py
+++ b/dbus-serialbattery/utils_can.py
@@ -34,7 +34,7 @@ class CanReceiverThread(threading.Thread):
         self.message_cache = {}  # cache can frames here
         self.cache_lock = threading.Lock()  # lock for thread safety
         self._last_received_time = {}  # track last received time for each arbitration ID
-        self._last_cache_clean_time = 0 # last time the cached was cleaned (deleted too old values)
+        self._last_cache_clean_time = 0  # last time the cached was cleaned (deleted too old values)
         CanReceiverThread._instances[(channel, bustype)] = self
         self.daemon = True
         self._running = True  # flag to control the running state

--- a/dbus-serialbattery/utils_can.py
+++ b/dbus-serialbattery/utils_can.py
@@ -130,9 +130,12 @@ class CanReceiverThread(threading.Thread):
 
         :return: None
         """
-        # do this once 1 second to reduce load
+        # do this once a second to reduce load
         if self._last_cache_clean_time + 1 > self.current_time:
             return
+
+        # update time
+        _last_cache_clean_time = self.current_time
 
         with self.cache_lock:
             for arb_id in list(self._last_received_time.keys()):


### PR DESCRIPTION
All CAN frames will be cached for 5 seconds to guarantee that all values will be up to date ...
Frames older than 5 seconds will be removed from the cache, so that alarm frames for example fade out, if the alarm no longer exists