### PR TITLE
added initial support for Valence U-BMS on CAN

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -156,6 +156,7 @@ body:
         - Seplos
         - Seplos v3
         - Sinowealth
+        - Valence U-BMS
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/support_request.yml
+++ b/.github/ISSUE_TEMPLATE/support_request.yml
@@ -134,6 +134,7 @@ body:
         - Seplos
         - Seplos v3
         - Sinowealth
+        - Valence U-BMS
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Driver version greater or equal to `v2.0.20250207dev`
   * Changes to `config.default.ini`: `TEMPERATURE_SOURCE_BATTERY` is now a list of temperature sensors, so you can choose which sensors you want to use
+  * Added: UBMS CAN - support for Valence U-BMS by @gimx
 
 * Driver version greater or equal to `v2.0.20250107dev`
   * Changes to `config.default.ini`: `CELL_VOLTAGE_DIFF_KEEP_MAX_VOLTAGE_TIME_RESTART` was superseeded by `SWITCH_TO_FLOAT_CELL_VOLTAGE_DEVIATION`, which has a different behavior

--- a/dbus-serialbattery/bms/ubms_can.py
+++ b/dbus-serialbattery/bms/ubms_can.py
@@ -4,19 +4,17 @@
 # Added by https://github.com/gimx based on https://github.com/gimx/dbus_ubms
 
 # TODO, also upstream
-# - sum in cell voltage display is wrong (adding not only a string up) 
+# - sum in cell voltage display is wrong (adding not only a string up)
 #   and worse ignoring the correctly calculated one and setting CVL wrongly
 # - cell balancing status
-# - implement leveled warning->alarms->shutdown, protection bits is too constrained
 # - CAN masking for used ids only
-# - VMU keep alive cyclic message on successful connect, otherwise the BMS disconnects battery   
+# - VMU keep alive cyclic message on successful connect, otherwise the BMS disconnects battery
 
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-from battery import Battery, Cell, Protection
+from battery import Battery, Cell
 from utils import bytearray_to_string, logger
 from utils import (
-    is_bit_set,
     MAX_BATTERY_CHARGE_CURRENT,
     MAX_BATTERY_DISCHARGE_CURRENT,
     MAX_CELL_VOLTAGE,
@@ -24,8 +22,7 @@ from utils import (
     UBMS_CAN_MODULE_SERIES,
     UBMS_CAN_MODULE_PARALLEL,
 )
-from struct import unpack_from
-from time import sleep, time
+from time import time
 import sys
 import can
 import struct
@@ -36,61 +33,57 @@ class Ubms_Can(Battery):
     def __init__(self, port, baud, address):
         super(Ubms_Can, self).__init__(port, baud, address)
         self.type = self.BATTERYTYPE
-        #self.history.exclude_values_to_calculate = ["charge_cycles", "total_ah_drawn"]
+        # self.history.exclude_values_to_calculate = ["charge_cycles", "total_ah_drawn"]
 
         # If multiple BMS are used simultaneously, the device address can be set via the dip switches on the BMS
         # (default address is 0, all switches down) to change the CAN frame ID sent by the BMS
         self.device_address = int.from_bytes(address, byteorder="big") if address is not None else 0
-        self.last_error_time = 0
         self.error_active = False
         self.protocol_version = None
-        self.poll_interval = 100                                                                                                                                                              
-        self.type = self.BATTERYTYPE                                                                                                                                                          
-        self.last_error_time = time()                                                                                                                                                    
-        self.error_active = False                                                                                                                                                             
-                                                                                                                                                                                              
-        self.numberOfModules = UBMS_CAN_MODULE_SERIES * UBMS_CAN_MODULE_PARALLEL                                                                                                              
+        self.poll_interval = 100
+        self.last_error_time = time()
+        self.error_active = False
+
+        self.numberOfModules = UBMS_CAN_MODULE_SERIES * UBMS_CAN_MODULE_PARALLEL
         self.numberOfStrings = UBMS_CAN_MODULE_PARALLEL
         self.modulesInSeries = int(self.numberOfModules / self.numberOfStrings)
         self.cellsPerModule = 4
-        self.maxChargeVoltage = MAX_CELL_VOLTAGE * self.cellsPerModule * UBMS_CAN_MODULE_SERIES                                                                                                                                                       
+        self.maxChargeVoltage = MAX_CELL_VOLTAGE * self.cellsPerModule * UBMS_CAN_MODULE_SERIES
+        self.max_battery_voltage = self.maxChargeVoltage
+        self.min_battery_voltage = MIN_CELL_VOLTAGE * self.cellsPerModule * UBMS_CAN_MODULE_SERIES
+
         self.cell_count = self.numberOfModules * self.cellsPerModule
-        
-        self.cells = [Cell(False) for _ in range(self.cell_count)] 
-        
-        self.chargeComplete = 0                                                                                                                                                               
-        self.soc = 0                                                                                                                                                                          
-        self.mode = 0                                                                                                                                                                         
-        self.state = ""                                                                                                                                                                       
-        self.voltage = 0                                                                                                                                                                      
-        self.current = 0                                                                                                                                                                      
-        self.temperature = 0                                                                                                                                                                  
-        self.balanced = True                                                                                                                                                                  
-        self.voltageAndCellTAlarms = 0                                                                                                                                                        
-        self.internalErrors = 0                                                                                                                                                               
-        self.currentAndPcbTAlarms = 0                                                                                                                                                         
-        self.maxPcbTemperature = 0                                                                                                                                                            
-        self.maxCellTemperature = 0                                                                                                                                                           
-        self.minCellTemperature = 0                                                                                                                                                           
-                                                                                                                                                                                              
-        self.cellVoltages =[(0,0,0,0) for i in range(self.numberOfModules)]                                                                                                                   
-        self.moduleVoltage = [0 for i in range(self.numberOfModules)]                                                                                                                         
-        self.moduleCurrent = [0 for i in range(self.numberOfModules)]                                                                                                                         
-        self.moduleSoc = [0 for i in range(self.numberOfModules)]                                                                                                                             
-        self.maxCellVoltage = 3.2                                                                                                                                                             
-        self.minCellVoltage = 3.2                                                                                                                                                             
-        self.maxChargeCurrent = MAX_BATTERY_CHARGE_CURRENT                                                                                                                                    
-        self.maxDischargeCurrent = MAX_BATTERY_DISCHARGE_CURRENT                                                                                                                              
-        self.partnr = 0                                                                                                                                                                       
-        self.firmwareVersion = 'unknown'                                                                                                                                                      
-        self.numberOfModulesBalancing = 0                                                                                                                                                     
-        self.numberOfModulesCommunicating = 0                                                                                                                                                 
-        self.cyclicModeTask = None        
 
-        #below info/function unavailable in UBMS, contactor function is configuration dependent and cannot be used hardcoded                                                                                     
-        self.charge_fet = True                                                                                                                                                                
-        self.discharge_fet = True                                                                                                                                                             
+        self.cells = [Cell(False) for _ in range(self.cell_count)]
 
+        self.chargeComplete = 0
+        self.soc = 0
+        self.mode = 0
+        self.state = ""
+        self.voltage = 0
+        self.current = 0
+        self.temperature = 0
+        self.balanced = True
+        self.voltageAndCellTAlarms = 0
+        self.internalErrors = 0
+        self.currentAndPcbTAlarms = 0
+        self.maxPcbTemperature = 0
+        self.maxCellTemperature = 0
+        self.minCellTemperature = 0
+
+        self.cellVoltages = [(0, 0, 0, 0) for i in range(self.numberOfModules)]
+        self.moduleVoltage = [0 for i in range(self.numberOfModules)]
+        self.moduleCurrent = [0 for i in range(self.numberOfModules)]
+        self.moduleSoc = [0 for i in range(self.numberOfModules)]
+        self.maxCellVoltage = 3.2
+        self.minCellVoltage = 3.2
+        self.maxChargeCurrent = MAX_BATTERY_CHARGE_CURRENT
+        self.maxDischargeCurrent = MAX_BATTERY_DISCHARGE_CURRENT
+        self.partnr = 0
+        self.firmwareVersion = "unknown"
+        self.numberOfModulesBalancing = 0
+        self.numberOfModulesCommunicating = 0
+        self.cyclicModeTask = None
 
     BATTERYTYPE = "UBMS CAN"
 
@@ -139,39 +132,38 @@ class Ubms_Can(Battery):
         # Return True if success, False for failure
 
         found = 0
-        
-        for frame_id, data in self.can_transport_interface.can_message_cache_callback().items():
-            msg = can.Message(
-                arbitration_id=frame_id, data=data, is_extended_id=True
-            )
- 
-            if msg.arbitration_id == 0x180:                                                                            
-               self.firmwareVersion = msg.data[0]                                                                                         
-#               self.bms_type = msg.data[3]
-               logger.info("Found Valence U-BMS type %i with FW v%i.", msg.data[3], msg.data[0])
-               if self.hardware_version is None:                                                                                                                                                     
-                   self.hardware_version = str(msg.data[4])     
-               
-               found = found | 1 
-               
-            elif msg.arbitration_id == 0xc0:
-            # status message received
-                logger.info("U-BMS is in mode %x with %i modules communicating.", msg.data[1], msg.data[5])
-                if (msg.data[2] & 1 != 0): logger.info("The number of modules communicating is less than configured.")
-                if (msg.data[3] & 2 != 0): logger.info("The number of modules communicating is higher than configured.")
-                
-                found = found | 2 
-        
-            elif msg.arbitration_id == 0xc1:
-            # check pack voltage
-                if abs(2*msg.data[0] - self.maxChargeVoltage) > 0.15*self.maxChargeVoltage:
-                    logger.error("U-BMS pack voltage of %dV differs significantly from configured max charge voltage %dV.",  msg.data[0], self.maxChargeVoltage)
-                found = found | 4 
-           
 
-        if found >= 3 :
+        for frame_id, data in self.can_transport_interface.can_message_cache_callback().items():
+            msg = can.Message(arbitration_id=frame_id, data=data, is_extended_id=True)
+
+            if msg.arbitration_id == 0x180:
+                self.firmwareVersion = msg.data[0]
+                # self.bms_type = msg.data[3]
+                logger.info("Found Valence U-BMS type %i with FW v%i.", msg.data[3], msg.data[0])
+                if self.hardware_version is None:
+                    self.hardware_version = str(msg.data[4])
+
+                found = found | 1
+
+            elif msg.arbitration_id == 0xC0:
+                # status message received
+                logger.info("U-BMS is in mode %x with %i modules communicating.", msg.data[1], msg.data[5])
+                if msg.data[2] & 1 != 0:
+                    logger.info("The number of modules communicating is less than configured.")
+                if msg.data[3] & 2 != 0:
+                    logger.info("The number of modules communicating is higher than configured.")
+
+                found = found | 2
+
+            elif msg.arbitration_id == 0xC1:
+                # check pack voltage
+                if abs(2 * msg.data[0] - self.maxChargeVoltage) > 0.15 * self.maxChargeVoltage:
+                    logger.error("U-BMS pack voltage of %dV differs significantly from configured max charge voltage %dV.", msg.data[0], self.maxChargeVoltage)
+                found = found | 4
+
+        if found >= 3:
             return True
-        else: 
+        else:
             return False
 
     def refresh_data(self):
@@ -180,31 +172,32 @@ class Ubms_Can(Battery):
         # Return True if success, False for failure
         result = False
 
-        #decode all queued CAN messages
+        # decode all queued CAN messages
         result = self.decode_can()
-        
-        if result is True:
-           #convert to alarms to protection bits
-           self.to_protection_bits()
-           
-           self.update_cell_voltages()
 
-        return result 
+        if result is True:
+            # convert to alarms to protection bits
+            self.to_protection_bits()
+
+            self.update_cell_voltages()
+
+        return result
 
     def to_protection_bits(self):
-        self.protection.low_cell_voltage =  (self.voltageAndCellTAlarms & 0x10)>>3
-        self.protection.high_cell_voltage =  (self.voltageAndCellTAlarms & 0x20)>>4
-        self.protection.low_soc = (self.voltageAndCellTAlarms & 0x08)>>3
-        self.protection.high_discharge_current = (self.currentAndPcbTAlarms & 0x3)
+        self.protection.low_cell_voltage = (self.voltageAndCellTAlarms & 0x10) >> 3
+        self.protection.high_cell_voltage = (self.voltageAndCellTAlarms & 0x20) >> 4
+        self.protection.low_soc = (self.voltageAndCellTAlarms & 0x08) >> 3
+        self.protection.high_discharge_current = self.currentAndPcbTAlarms & 0x3
 
-        #flag high cell temperature alarm and high pcb temperature alarm
-        self.protection.high_temperature =  (self.voltageAndCellTAlarms &0x6)>>1 | (self.currentAndPcbTAlarms & 0x18)>>3
-        self.protection.low_temperature = (self.mode & 0x60)>>5
+        # flag high cell temperature alarm and high pcb temperature alarm
+        self.protection.high_temperature = (self.voltageAndCellTAlarms & 0x6) >> 1 | (self.currentAndPcbTAlarms & 0x18) >> 3
+        self.protection.low_temperature = (self.mode & 0x60) >> 5
 
-        #FIXME check if any alarms came up
-	#logger.debug("alarms %d" % (alarms))
-        #self.last_error_time = time()
-        #self.error_active = True
+        # FIXME check if any alarms came up
+
+    # logger.debug("alarms %d" % (alarms))
+    # self.last_error_time = time()
+    # self.error_active = True
 
     def reset_protection_bits(self):
         self.protection.high_cell_voltage = 0
@@ -229,83 +222,78 @@ class Ubms_Can(Battery):
         chain = itertools.chain(*self.cellVoltages)
         flatVList = list(chain)
         for i in range(self.cell_count):
-            self.cells[i].voltage = flatVList[i]/1000.0 
-        #self.voltage = self.get_cell_voltage_sum()
-    
+            self.cells[i].voltage = flatVList[i] / 1000.0
+
     def decode_can(self):
 
         for frame_id, data in self.can_transport_interface.can_message_cache_callback().items():
-            msg = can.Message(
-                arbitration_id=frame_id, data=data, is_extended_id=True
-            )
+            msg = can.Message(arbitration_id=frame_id, data=data, is_extended_id=True)
 
-            if msg.arbitration_id == 0xc0:
+            if msg.arbitration_id == 0xC0:
                 self.soc = msg.data[0]
                 self.mode = msg.data[1]
-                self.balancing = True if (self.mode &0x10) != 0 else False 
+                self.balancing = True if (self.mode & 0x10) != 0 else False
                 self.voltageAndCellTAlarms = msg.data[2]
                 self.internalErrors = msg.data[3]
                 self.currentAndPcbTAlarms = msg.data[4]
 
                 self.numberOfModulesCommunicating = msg.data[5]
 
-                #if no module flagged missing and not too many on the bus, then this is the number the U-BMS was configured for
+                # if no module flagged missing and not too many on the bus, then this is the number the U-BMS was configured for
                 if (msg.data[2] & 1 == 0) and (msg.data[3] & 2 == 0):
                     self.numberOfModules = self.numberOfModulesCommunicating
 
                 self.numberOfModulesBalancing = msg.data[6]
-                                                            
 
-            elif msg.arbitration_id == 0xc1:       
-#            self.voltage = msg.data[0] * 1 # voltage scale factor depends on BMS configuration, so unusable 
-                self.current = struct.unpack('Bb',msg.data[0:2])[1]
+            elif msg.arbitration_id == 0xC1:
+                # self.voltage = msg.data[0] * 1 # voltage scale factor depends on BMS configuration, so unusable
+                self.current = struct.unpack("Bb", msg.data[0:2])[1]
 
-                if (self.mode & 0x2) != 0 : #provided in drive mode only
-                    self.maxDischargeCurrent =  int((struct.unpack('<h', msg.data[3:5])[0])/10)
-                    self.maxChargeCurrent =  int((struct.unpack('<h', bytearray([msg.data[5],msg.data[7]]))[0])/5)
+                if (self.mode & 0x2) != 0:  # provided in drive mode only
+                    self.maxDischargeCurrent = int((struct.unpack("<h", msg.data[3:5])[0]) / 10)
+                    self.maxChargeCurrent = int((struct.unpack("<h", bytearray([msg.data[5], msg.data[7]]))[0]) / 5)
 
-            elif msg.arbitration_id == 0xc2:                                                                                   
-                #data valid in charge mode only                                                                                                                 
-                if (self.mode & 0x1) != 0:                                                                                                                      
-                    self.chargeComplete = (msg.data[3] & 0x4) >> 2                                                                                              
-                    self.maxChargeVoltage2 = struct.unpack('<h', msg.data[1:3])[0]                                                                              
-                                                                                                                                                                
-                    #only apply lower charge current when equalizing                                                                                            
-                    if (self.mode & 0x18) == 0x18 :                                                                                                             
-                        self.maxChargeCurrent = msg.data[0]                                                                                                     
-                    else:                                                                                                                                       
-                    #allow charge with 0.1C                                                                                                                     
-                        self.maxChargeCurrent = self.capacity * 0.1                   
+            elif msg.arbitration_id == 0xC2:
+                # data valid in charge mode only
+                if (self.mode & 0x1) != 0:
+                    self.chargeComplete = (msg.data[3] & 0x4) >> 2
+                    self.maxChargeVoltage2 = struct.unpack("<h", msg.data[1:3])[0]
 
+                    # only apply lower charge current when equalizing
+                    if (self.mode & 0x18) == 0x18:
+                        self.maxChargeCurrent = msg.data[0]
+                    else:
+                        # allow charge with 0.1C
+                        self.maxChargeCurrent = self.capacity * 0.1
 
-            elif msg.arbitration_id == 0xc4:
-                self.maxCellTemperature =  msg.data[0]-40
-                self.minCellTemperature =  msg.data[1]-40
-                self.maxPcbTemperature =  msg.data[3]-40
-                self.maxCellVoltage =  struct.unpack('<h', msg.data[4:6])[0]*0.001
-                self.minCellVoltage =  struct.unpack('<h', msg.data[6:8])[0]*0.001
+            elif msg.arbitration_id == 0xC4:
+                self.maxCellTemperature = msg.data[0] - 40
+                self.minCellTemperature = msg.data[1] - 40
+                self.maxPcbTemperature = msg.data[3] - 40
+                self.maxCellVoltage = struct.unpack("<h", msg.data[4:6])[0] * 0.001
+                self.minCellVoltage = struct.unpack("<h", msg.data[6:8])[0] * 0.001
                 self.cell_max_voltage = self.maxCellVoltage
                 self.cell_min_voltage = self.minCellVoltage
 
-#FIXME Intra-module balance flags, 1 bit per cell, 1 byte per module 
-#            elif msg.arbitration_id in [0x26A, 0x26B]:
-#                for m in range [(msg.arbitration_id-0x2A) * 8, ((msg.arbitration_id-0x2A + 1) * 8) -1]:
-#                    self.cells[m * self.cellsPerModule + 0].balance = True if ((msg.data[m]>>c) & 1) != 0 else False     
-#                    self.cells[m * self.cellsPerModule + 1].balance = True if ((msg.data[m]>>1) & 1) != 0 else False 
-#                    self.cells[m * self.cellsPerModule + 2].balance = True if ((msg.data[m]>>2) & 1) != 0 else False 
-#                    self.cells[m * self.cellsPerModule + 3].balance = True if ((msg.data[m]>>3) & 1) != 0 else False 
-  
+            # FIXME Intra-module balance flags, 1 bit per cell, 1 byte per module
+            # elif msg.arbitration_id in [0x26A, 0x26B]:
+            #     for m in range [(msg.arbitration_id-0x2A) * 8, ((msg.arbitration_id-0x2A + 1) * 8) -1]:
+            #         self.cells[m * self.cellsPerModule + 0].balance = True if ((msg.data[m]>>c) & 1) != 0 else False
+            #         self.cells[m * self.cellsPerModule + 1].balance = True if ((msg.data[m]>>1) & 1) != 0 else False
+            #         self.cells[m * self.cellsPerModule + 2].balance = True if ((msg.data[m]>>2) & 1) != 0 else False
+            #         self.cells[m * self.cellsPerModule + 3].balance = True if ((msg.data[m]>>3) & 1) != 0 else False
+
             elif msg.arbitration_id in [0x350, 0x352, 0x354, 0x356, 0x358, 0x35A, 0x35C, 0x35E, 0x360, 0x362, 0x364]:
                 module = (msg.arbitration_id - 0x350) >> 1
-                self.cellVoltages[module] = struct.unpack('>hhh', msg.data[2:msg.dlc])
+                self.cellVoltages[module] = struct.unpack(">hhh", msg.data[2 : msg.dlc])
 
             elif msg.arbitration_id in [0x351, 0x353, 0x355, 0x357, 0x359, 0x35B, 0x35D, 0x35F, 0x361, 0x363, 0x365]:
                 module = (msg.arbitration_id - 0x351) >> 1
-                self.cellVoltages[module] = self.cellVoltages[module]+ tuple(struct.unpack('>h', msg.data[2:msg.dlc]))
+                self.cellVoltages[module] = self.cellVoltages[module] + tuple(struct.unpack(">h", msg.data[2 : msg.dlc]))
                 self.moduleVoltage[module] = sum(self.cellVoltages[module])
 
-                #update pack voltage at each arrival of the first strings last modules cell voltages
-                if module == self.numberOfModules-1:
-                    self.voltage = sum(self.moduleVoltage[0:self.modulesInSeries])/1000.0
-                    
+                # update pack voltage at each arrival of the first strings last modules cell voltages
+                if module == self.numberOfModules - 1:
+                    self.voltage = sum(self.moduleVoltage[0 : self.modulesInSeries]) / 1000.0
+
         return True

--- a/dbus-serialbattery/bms/ubms_can.py
+++ b/dbus-serialbattery/bms/ubms_can.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+
+# NOTES
+# Added by https://github.com/gimx based on https://github.com/gimx/dbus_ubms
+
+# TODO, also upstream
+# - sum in cell voltage display is wrong (adding not only a string up) 
+#   and worse ignoring the correctly calculated one and setting CVL wrongly
+# - cell balancing status
+# - implement leveled warning->alarms->shutdown, protection bits is too constrained
+# - CAN masking for used ids only
+# - VMU keep alive cyclic message on successful connect, otherwise the BMS disconnects battery   
+
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+from battery import Battery, Cell, Protection
+from utils import bytearray_to_string, logger
+from utils import (
+    is_bit_set,
+    MAX_BATTERY_CHARGE_CURRENT,
+    MAX_BATTERY_DISCHARGE_CURRENT,
+    MAX_CELL_VOLTAGE,
+    MIN_CELL_VOLTAGE,
+    UBMS_CAN_MODULE_SERIES,
+    UBMS_CAN_MODULE_PARALLEL,
+)
+from struct import unpack_from
+from time import sleep, time
+import sys
+import can
+import struct
+import itertools
+
+
+class Ubms_Can(Battery):
+    def __init__(self, port, baud, address):
+        super(Ubms_Can, self).__init__(port, baud, address)
+        self.type = self.BATTERYTYPE
+        #self.history.exclude_values_to_calculate = ["charge_cycles", "total_ah_drawn"]
+
+        # If multiple BMS are used simultaneously, the device address can be set via the dip switches on the BMS
+        # (default address is 0, all switches down) to change the CAN frame ID sent by the BMS
+        self.device_address = int.from_bytes(address, byteorder="big") if address is not None else 0
+        self.last_error_time = 0
+        self.error_active = False
+        self.protocol_version = None
+        self.poll_interval = 100                                                                                                                                                              
+        self.type = self.BATTERYTYPE                                                                                                                                                          
+        self.last_error_time = time()                                                                                                                                                    
+        self.error_active = False                                                                                                                                                             
+                                                                                                                                                                                              
+        self.numberOfModules = UBMS_CAN_MODULE_SERIES * UBMS_CAN_MODULE_PARALLEL                                                                                                              
+        self.numberOfStrings = UBMS_CAN_MODULE_PARALLEL
+        self.modulesInSeries = int(self.numberOfModules / self.numberOfStrings)
+        self.cellsPerModule = 4
+        self.maxChargeVoltage = MAX_CELL_VOLTAGE * self.cellsPerModule * UBMS_CAN_MODULE_SERIES                                                                                                                                                       
+        self.cell_count = self.numberOfModules * self.cellsPerModule
+        
+        self.cells = [Cell(False) for _ in range(self.cell_count)] 
+        
+        self.chargeComplete = 0                                                                                                                                                               
+        self.soc = 0                                                                                                                                                                          
+        self.mode = 0                                                                                                                                                                         
+        self.state = ""                                                                                                                                                                       
+        self.voltage = 0                                                                                                                                                                      
+        self.current = 0                                                                                                                                                                      
+        self.temperature = 0                                                                                                                                                                  
+        self.balanced = True                                                                                                                                                                  
+        self.voltageAndCellTAlarms = 0                                                                                                                                                        
+        self.internalErrors = 0                                                                                                                                                               
+        self.currentAndPcbTAlarms = 0                                                                                                                                                         
+        self.maxPcbTemperature = 0                                                                                                                                                            
+        self.maxCellTemperature = 0                                                                                                                                                           
+        self.minCellTemperature = 0                                                                                                                                                           
+                                                                                                                                                                                              
+        self.cellVoltages =[(0,0,0,0) for i in range(self.numberOfModules)]                                                                                                                   
+        self.moduleVoltage = [0 for i in range(self.numberOfModules)]                                                                                                                         
+        self.moduleCurrent = [0 for i in range(self.numberOfModules)]                                                                                                                         
+        self.moduleSoc = [0 for i in range(self.numberOfModules)]                                                                                                                             
+        self.maxCellVoltage = 3.2                                                                                                                                                             
+        self.minCellVoltage = 3.2                                                                                                                                                             
+        self.maxChargeCurrent = MAX_BATTERY_CHARGE_CURRENT                                                                                                                                    
+        self.maxDischargeCurrent = MAX_BATTERY_DISCHARGE_CURRENT                                                                                                                              
+        self.partnr = 0                                                                                                                                                                       
+        self.firmwareVersion = 'unknown'                                                                                                                                                      
+        self.numberOfModulesBalancing = 0                                                                                                                                                     
+        self.numberOfModulesCommunicating = 0                                                                                                                                                 
+        self.cyclicModeTask = None        
+
+        #below info/function unavailable in UBMS, contactor function is configuration dependent and cannot be used hardcoded                                                                                     
+        self.charge_fet = True                                                                                                                                                                
+        self.discharge_fet = True                                                                                                                                                             
+
+
+    BATTERYTYPE = "UBMS CAN"
+
+    def connection_name(self) -> str:
+        return f"CAN socketcan:{self.port}" + (f"__{self.device_address}" if self.device_address != 0 else "")
+
+    def unique_identifier(self) -> str:
+        """
+        Used to identify a BMS when multiple BMS are connected
+        Provide a unique identifier from the BMS to identify a BMS, if multiple same BMS are connected
+        e.g. the serial number
+        If there is no such value, please remove this function
+        """
+        return self.port + ("__" + bytearray_to_string(self.address).replace("\\", "0") if self.address is not None else "")
+
+    def test_connection(self):
+        """
+        call a function that will connect to the battery, send a command and retrieve the result.
+        The result or call should be unique to this BMS. Battery name or version, etc.
+        Return True if success, False for failure
+        """
+        result = False
+        try:
+            # get settings to check if the data is valid and the connection is working
+            result = self.get_settings()
+
+            # get the rest of the data to be sure, that all data is valid and the correct battery type is recognized
+            # only read next data if the first one was successful, this saves time when checking multiple battery types
+            result = result and self.refresh_data()
+        except Exception:
+            (
+                exception_type,
+                exception_object,
+                exception_traceback,
+            ) = sys.exc_info()
+            file = exception_traceback.tb_frame.f_code.co_filename
+            line = exception_traceback.tb_lineno
+            logger.error(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
+            result = False
+
+        return result
+
+    def get_settings(self):
+        # After successful connection get_settings() will be called to set up the battery
+        # Set the current limits, populate cell count, etc
+        # Return True if success, False for failure
+
+        found = 0
+        
+        for frame_id, data in self.can_transport_interface.can_message_cache_callback().items():
+            msg = can.Message(
+                arbitration_id=frame_id, data=data, is_extended_id=True
+            )
+ 
+            if msg.arbitration_id == 0x180:                                                                            
+               self.firmwareVersion = msg.data[0]                                                                                         
+#               self.bms_type = msg.data[3]
+               logger.info("Found Valence U-BMS type %i with FW v%i.", msg.data[3], msg.data[0])
+               if self.hardware_version is None:                                                                                                                                                     
+                   self.hardware_version = str(msg.data[4])     
+               
+               found = found | 1 
+               
+            elif msg.arbitration_id == 0xc0:
+            # status message received
+                logger.info("U-BMS is in mode %x with %i modules communicating.", msg.data[1], msg.data[5])
+                if (msg.data[2] & 1 != 0): logger.info("The number of modules communicating is less than configured.")
+                if (msg.data[3] & 2 != 0): logger.info("The number of modules communicating is higher than configured.")
+                
+                found = found | 2 
+        
+            elif msg.arbitration_id == 0xc1:
+            # check pack voltage
+                if abs(2*msg.data[0] - self.maxChargeVoltage) > 0.15*self.maxChargeVoltage:
+                    logger.error("U-BMS pack voltage of %dV differs significantly from configured max charge voltage %dV.",  msg.data[0], self.maxChargeVoltage)
+                found = found | 4 
+           
+
+        if found >= 3 :
+            return True
+        else: 
+            return False
+
+    def refresh_data(self):
+        # call all functions that will refresh the battery data.
+        # This will be called for every iteration (1 second)
+        # Return True if success, False for failure
+        result = False
+
+        #decode all queued CAN messages
+        result = self.decode_can()
+        
+        if result is True:
+           #convert to alarms to protection bits
+           self.to_protection_bits()
+           
+           self.update_cell_voltages()
+
+        return result 
+
+    def to_protection_bits(self):
+        self.protection.low_cell_voltage =  (self.voltageAndCellTAlarms & 0x10)>>3
+        self.protection.high_cell_voltage =  (self.voltageAndCellTAlarms & 0x20)>>4
+        self.protection.low_soc = (self.voltageAndCellTAlarms & 0x08)>>3
+        self.protection.high_discharge_current = (self.currentAndPcbTAlarms & 0x3)
+
+        #flag high cell temperature alarm and high pcb temperature alarm
+        self.protection.high_temperature =  (self.voltageAndCellTAlarms &0x6)>>1 | (self.currentAndPcbTAlarms & 0x18)>>3
+        self.protection.low_temperature = (self.mode & 0x60)>>5
+
+        #FIXME check if any alarms came up
+	#logger.debug("alarms %d" % (alarms))
+        #self.last_error_time = time()
+        #self.error_active = True
+
+    def reset_protection_bits(self):
+        self.protection.high_cell_voltage = 0
+        self.protection.low_cell_voltage = 0
+        self.protection.high_voltage = 0
+        self.protection.low_voltage = 0
+        self.protection.cell_imbalance = 0
+        self.protection.high_discharge_current = 0
+        self.protection.high_charge_current = 0
+
+        # there is just a BMS and Battery temperature_ alarm (not for charge and discharge)
+        self.protection.high_charge_temperature = 0
+        self.protection.high_temperature = 0
+        self.protection.low_charge_temperature = 0
+        self.protection.low_temperature = 0
+        self.protection.high_charge_temperature = 0
+        self.protection.high_temperature = 0
+        self.protection.low_soc = 0
+        self.protection.internal_failure = 0
+
+    def update_cell_voltages(self):
+        chain = itertools.chain(*self.cellVoltages)
+        flatVList = list(chain)
+        for i in range(self.cell_count):
+            self.cells[i].voltage = flatVList[i]/1000.0 
+        #self.voltage = self.get_cell_voltage_sum()
+    
+    def decode_can(self):
+
+        for frame_id, data in self.can_transport_interface.can_message_cache_callback().items():
+            msg = can.Message(
+                arbitration_id=frame_id, data=data, is_extended_id=True
+            )
+
+            if msg.arbitration_id == 0xc0:
+                self.soc = msg.data[0]
+                self.mode = msg.data[1]
+                self.balancing = True if (self.mode &0x10) != 0 else False 
+                self.voltageAndCellTAlarms = msg.data[2]
+                self.internalErrors = msg.data[3]
+                self.currentAndPcbTAlarms = msg.data[4]
+
+                self.numberOfModulesCommunicating = msg.data[5]
+
+                #if no module flagged missing and not too many on the bus, then this is the number the U-BMS was configured for
+                if (msg.data[2] & 1 == 0) and (msg.data[3] & 2 == 0):
+                    self.numberOfModules = self.numberOfModulesCommunicating
+
+                self.numberOfModulesBalancing = msg.data[6]
+                                                            
+
+            elif msg.arbitration_id == 0xc1:       
+#            self.voltage = msg.data[0] * 1 # voltage scale factor depends on BMS configuration, so unusable 
+                self.current = struct.unpack('Bb',msg.data[0:2])[1]
+
+                if (self.mode & 0x2) != 0 : #provided in drive mode only
+                    self.maxDischargeCurrent =  int((struct.unpack('<h', msg.data[3:5])[0])/10)
+                    self.maxChargeCurrent =  int((struct.unpack('<h', bytearray([msg.data[5],msg.data[7]]))[0])/5)
+
+            elif msg.arbitration_id == 0xc2:                                                                                   
+                #data valid in charge mode only                                                                                                                 
+                if (self.mode & 0x1) != 0:                                                                                                                      
+                    self.chargeComplete = (msg.data[3] & 0x4) >> 2                                                                                              
+                    self.maxChargeVoltage2 = struct.unpack('<h', msg.data[1:3])[0]                                                                              
+                                                                                                                                                                
+                    #only apply lower charge current when equalizing                                                                                            
+                    if (self.mode & 0x18) == 0x18 :                                                                                                             
+                        self.maxChargeCurrent = msg.data[0]                                                                                                     
+                    else:                                                                                                                                       
+                    #allow charge with 0.1C                                                                                                                     
+                        self.maxChargeCurrent = self.capacity * 0.1                   
+
+
+            elif msg.arbitration_id == 0xc4:
+                self.maxCellTemperature =  msg.data[0]-40
+                self.minCellTemperature =  msg.data[1]-40
+                self.maxPcbTemperature =  msg.data[3]-40
+                self.maxCellVoltage =  struct.unpack('<h', msg.data[4:6])[0]*0.001
+                self.minCellVoltage =  struct.unpack('<h', msg.data[6:8])[0]*0.001
+                self.cell_max_voltage = self.maxCellVoltage
+                self.cell_min_voltage = self.minCellVoltage
+
+#FIXME Intra-module balance flags, 1 bit per cell, 1 byte per module 
+#            elif msg.arbitration_id in [0x26A, 0x26B]:
+#                for m in range [(msg.arbitration_id-0x2A) * 8, ((msg.arbitration_id-0x2A + 1) * 8) -1]:
+#                    self.cells[m * self.cellsPerModule + 0].balance = True if ((msg.data[m]>>c) & 1) != 0 else False     
+#                    self.cells[m * self.cellsPerModule + 1].balance = True if ((msg.data[m]>>1) & 1) != 0 else False 
+#                    self.cells[m * self.cellsPerModule + 2].balance = True if ((msg.data[m]>>2) & 1) != 0 else False 
+#                    self.cells[m * self.cellsPerModule + 3].balance = True if ((msg.data[m]>>3) & 1) != 0 else False 
+  
+            elif msg.arbitration_id in [0x350, 0x352, 0x354, 0x356, 0x358, 0x35A, 0x35C, 0x35E, 0x360, 0x362, 0x364]:
+                module = (msg.arbitration_id - 0x350) >> 1
+                self.cellVoltages[module] = struct.unpack('>hhh', msg.data[2:msg.dlc])
+
+            elif msg.arbitration_id in [0x351, 0x353, 0x355, 0x357, 0x359, 0x35B, 0x35D, 0x35F, 0x361, 0x363, 0x365]:
+                module = (msg.arbitration_id - 0x351) >> 1
+                self.cellVoltages[module] = self.cellVoltages[module]+ tuple(struct.unpack('>h', msg.data[2:msg.dlc]))
+                self.moduleVoltage[module] = sum(self.cellVoltages[module])
+
+                #update pack voltage at each arrival of the first strings last modules cell voltages
+                if module == self.numberOfModules-1:
+                    self.voltage = sum(self.moduleVoltage[0:self.modulesInSeries])/1000.0
+                    
+        return True

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -572,3 +572,12 @@ GREENMETER_ADDRESS  = 1
 LIPRO_START_ADDRESS = 2
 LIPRO_END_ADDRESS   = 4
 LIPRO_CELL_COUNT    = 15
+
+; -- UBMS settings                                                                         
+; Predefines for Valence U-BMS (Ubms_can)                                                                            
+; This BMS supports multiple strings of modules (of 4 cells each) in series and parallel.                            
+; And while the number of communicating modules can be established from data on bus, its safer                       
+; to specify the module configuration directly, i.e. series/parallel                                                 
+; The configured battery (dis)charge voltage and currents are applied to this configuration                          
+UBMS_CAN_MODULE_SERIES = 4                                                                                          
+UBMS_CAN_MODULE_PARALLEL = 2   

--- a/dbus-serialbattery/dbus-serialbattery.py
+++ b/dbus-serialbattery/dbus-serialbattery.py
@@ -352,11 +352,13 @@ def main():
         """
         from bms.daly_can import Daly_Can
         from bms.jkbms_can import Jkbms_Can
+        from bms.ubms_can import Ubms_Can
 
         # only try CAN BMS on CAN port
         supported_bms_types = [
             {"bms": Daly_Can},
             {"bms": Jkbms_Can},
+            {"bms": Ubms_Can},
         ]
 
         # check if BMS_TYPE is not empty and all BMS types in the list are supported

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -451,6 +451,10 @@ LIPRO_START_ADDRESS: int = get_int_from_config("DEFAULT", "LIPRO_START_ADDRESS")
 LIPRO_END_ADDRESS: int = get_int_from_config("DEFAULT", "LIPRO_END_ADDRESS")
 LIPRO_CELL_COUNT: int = get_int_from_config("DEFAULT", "LIPRO_CELL_COUNT")
 
+# -- UBMS settings
+UBMS_CAN_MODULE_SERIES: int = get_int_from_config("DEFAULT", "UBMS_CAN_MODULE_SERIES")
+UBMS_CAN_MODULE_PARALLEL: int = get_int_from_config("DEFAULT", "UBMS_CAN_MODULE_PARALLEL")
+
 
 # FUNCTIONS
 def constrain(val: float, min_val: float, max_val: float) -> float:


### PR DESCRIPTION
Hi, 

it took longer than anticipated but eventually I am done supporting the Valence U-BMS on can. There are still a number of things TODO where I believe some of them require upstream fixes. A significant difference to the BMS that are supported so far is, that the U-BMS supports multiple strings of modules of 4 cells each, e.g. a 4(x4)s2p config I have at home. That means it can not be assumed that the sum of the cell voltages equals the pack voltage. Each battery module features its own internal balancer. I did not dig deeper, but despite calculating the correct pack voltage, it is either ignored or overwritten upstream. In my case the cell voltage tab shows twice the voltage (becaue of 2 parallel strings), while the main menu overview correctly reports the self.voltage value that has been calculated in the code. I have also attached a candump which you might want to use for testing.
[ubms_can_dump.log](https://github.com/user-attachments/files/19403964/ubms_can_dump.log)

Cheers,
Torsten

- [x] 🚨 Make sure the GitHub Actions run fine in your repository. In order to make the GitHub Actions run please select in your repository settings under `Actions` -&gt; `General` -&gt; `Actions permissions` the option `Allow all actions and reusable workflows`. Check also in your repository settings under `Actions` -&gt; `General` -&gt; `Workflow permissions` if `Read and write permissions` are selected. After this changes you have to make a new commit, if you don't see any Actions run. This will check your code for Flake8 and Black Lint errors. [Here](https://py-vscode.readthedocs.io/en/latest/files/linting.html) is a short instruction on how to set up Flake8 and Black Lint checks in VS Code. This will save you a lot of time.
- [x] Add your battery class and battery class import in alphabetical order in the [`etc/dbus-serialbattery/dbus-serialbattery.py`](https://github.com/mr-manuel/venus-os_dbus-serialbattery/blob/master/dbus-serialbattery/dbus-serialbattery.py)
- [x] Add your BMS to the [BMS feature comparison](../general/features#bms-feature-comparison) page by editing [`docs/general/features.md`](https://github.com/mr-manuel/venus-os_dbus-serialbattery_docs/blob/master/docs/general/features.md)
- [x] Add your BMS to the [Supported BMS](../general/supported-bms) page by editing [`docs/general/supported-bms.md`](https://github.com/mr-manuel/venus-os_dbus-serialbattery_docs/blob/master/docs/general/supported-bms.md)
- [x] Do not import wildcards `*`
- [x] If available populate `self.max_battery_charge_current` and `self.max_battery_discharge_current` with values read from the BMS
- [x] If available populate `self.unique_identifier` with a unique value to distinguish the BMS in a multiple battery setup
- [x] If your BMS don't run with the default settings add installation notes to the [How to install, update, disable, enable and uninstall](../general/install.md#bms-specific-settings) [`docs/general/install.md`](https://github.com/mr-manuel/venus-os_dbus-serialbattery_docs/blob/master/docs/general/install.md)
- [x] If your BMS needs custom settings that the user should be able to change, add it below the `; --------- BMS specific settings ---------` section in the [`etc/dbus-serialbattery/config.default.ini`](https://github.com/mr-manuel/venus-os_dbus-serialbattery/blob/master/dbus-serialbattery/config.default.ini)
- [x] Add the new BMS to the available BMS list under `; --------- Additional settings ---------` in the [`config.default.ini`](https://github.com/mr-manuel/venus-os_dbus-serialbattery/blob/master/dbus-serialbattery/config.default.ini)
- [x] Add an entry to the [CHANGELOG.md](https://github.com/mr-manuel/venus-os_dbus-serialbattery/blob/master/CHANGELOG.md)
- [x] Add an entry in the issue template [`bug_report.yml`](https://github.com/mr-manuel/venus-os_dbus-serialbattery/blob/master/.github/ISSUE_TEMPLATE/bug_report.yml?plain=1) under `id: bms_type`
- [x] Add an entry in the issue template [`support_request.yml`](https://github.com/mr-manuel/venus-os_dbus-serialbattery/blob/master/.github/ISSUE_TEMPLATE/support_request.yml?plain=1) under `id: bms_type`