### PR TITLE
Fix: Use fixed 0x01 for COMMAND INFO per Tian-Power BMS protocol 2.2.3

### DIFF
--- a/dbus-serialbattery/bms/daren_485.py
+++ b/dbus-serialbattery/bms/daren_485.py
@@ -606,7 +606,7 @@ class Daren485(Battery):
         Example command (mark the \r at the end):
         ~22014A42E00201FD28␍
         """
-        return self.create_command(self.address, b"\x4a", b"\x42","01")
+        return self.create_command(self.address, b"\x4a", b"\x42", "01")
 
     def create_command_get_manufacturer_info(self):
         """

--- a/dbus-serialbattery/bms/daren_485.py
+++ b/dbus-serialbattery/bms/daren_485.py
@@ -568,7 +568,7 @@ class Daren485(Battery):
         Example command (mark the \r at the end):
         ~22014A47E00201FD23␍
         """
-        return self.create_command(self.address, b"\x4a", b"\x47", self.address.hex().upper())
+        return self.create_command(self.address, b"\x4a", b"\x47", "01")
 
     def create_command_get_mfg_params(self):
         """
@@ -606,7 +606,7 @@ class Daren485(Battery):
         Example command (mark the \r at the end):
         ~22014A42E00201FD28␍
         """
-        return self.create_command(self.address, b"\x4a", b"\x42", self.address.hex().upper())
+        return self.create_command(self.address, b"\x4a", b"\x42","01")
 
     def create_command_get_manufacturer_info(self):
         """


### PR DESCRIPTION
This PR fixes the command frame sent to Tian-Power BMS devices for telemetry retrieval.

According to the official [Tian-Power Communication Protocol v2.2.3](https://github.com/cpttinkering/daren-485/blob/main/Docs/BMS-BASEN_Energy-Storage-protocol-En.pdf.pdf) , section 5.1 (Table 5), the COMMAND INFO field (i.e., the fifth byte after CID2) is fixed to 0x01 for requesting real-time telemetry. It should not be derived from the device address or any external logic.

Reference:

“At this time, the specific COMMAND GROUP is fixed to 01H, indicating that the first group of battery telemetry data is acquired.”

This fix ensures protocol compliance and improves compatibility with Tian-Power BMS units.