### PR TITLE
Refactor condition to check for missing data

### DIFF
--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -356,7 +356,7 @@ class Jkbms_pb(Battery):
             self.LENGTH_SIZE,  # ignored
             battery_online=self.online,
         )
-        if data is False:
+        if not data:
             return False
 
         # be = ''.join(format(x, ' 02X') for x in data)


### PR DESCRIPTION
Avoid not proper handled `TypeError: 'NoneType' object is not subscriptable`


```
@4000000068b973dd1eb993e4 ERROR:SerialBattery:Exception occurred: OSError(71, 'Protocol error') of type <class 'OSError'> in /data/apps/dbus-serialbattery/utils.py line #831
@4000000068b973dd21464d8c Traceback (most recent call last):
@4000000068b973dd232fd5dc   File "/data/apps/dbus-serialbattery/dbushelper.py", line 781, in publish_battery
@4000000068b973dd232ff134     result = self.battery.refresh_data()
@4000000068b973dd232ffcec              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@4000000068b973dd2332008c   File "/data/apps/dbus-serialbattery/bms/jkbms_pb.py", line 173, in refresh_data
@4000000068b973dd23321414     return self.read_status_data()
@4000000068b973dd23321fcc            ^^^^^^^^^^^^^^^^^^^^^^^
@4000000068b973dd2332279c   File "/data/apps/dbus-serialbattery/bms/jkbms_pb.py", line 176, in read_status_data
@4000000068b973dd23323b24     status_data = self.read_serial_data_jkbms_pb(self.command_status, 299)
@4000000068b973dd23324ac4                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@4000000068b973dd2333aa54   File "/data/apps/dbus-serialbattery/bms/jkbms_pb.py", line 368, in read_serial_data_jkbms_pb
@4000000068b973dd2333bddc     if data[0] == 0x55 and data[1] == 0xAA:
@4000000068b973dd2333c994        ~~~~^^^
@4000000068b973dd2335adf4 TypeError: 'NoneType' object is not subscriptable

```