### PR TITLE
Add option to select HCI for Jkbms_Ble on any system

### DIFF
--- a/dbus-serialbattery/bms/jkbms_ble.py
+++ b/dbus-serialbattery/bms/jkbms_ble.py
@@ -22,18 +22,23 @@ class Jkbms_Ble(Battery):
     BATTERYTYPE = "JKBMS BLE"
     resetting = False
 
-    def __init__(self, port, baud, address):
+    def __init__(self, port, baud, address, **kwargs):
         super(Jkbms_Ble, self).__init__(port, baud, address)
         self.address = address
+        self.adapter = kwargs.get("adapter")
         self.type = self.BATTERYTYPE
-        self.jk = Jkbms_Brn(address, lambda: self.reset_bluetooth())
+        self.jk = Jkbms_Brn(address, lambda: self.reset_bluetooth(), adapter=self.adapter)
         self.unique_identifier_tmp = ""
         self.history.exclude_values_to_calculate = ["charge_cycles"]
 
         logger.info("Init of Jkbms_Ble at " + address)
 
     def connection_name(self) -> str:
-        return "BLE " + self.address
+        name = "BLE " + self.address
+        if self.adapter:
+            name = name + "@" + self.adapter
+
+        return name
 
     def custom_name(self) -> str:
         return "SerialBattery(" + self.type + ") " + self.address[-5:]

--- a/dbus-serialbattery/bms/jkbms_brn.py
+++ b/dbus-serialbattery/bms/jkbms_brn.py
@@ -148,8 +148,9 @@ class Jkbms_Brn:
     # translate info placeholder, since it depends on the bms_max_cell_count
     translate_cell_info = []
 
-    def __init__(self, addr, reset_bt_callback=None):
+    def __init__(self, addr, reset_bt_callback=None, **kwargs):
         self.address = addr
+        self.adapter = kwargs.get("adapter")
         self.bt_thread = None
         self.bt_thread_monitor = threading.Thread(target=self.monitor_scraping, name="Thread-JKBMS-Monitor")
         self.bt_reset = reset_bt_callback
@@ -449,11 +450,11 @@ class Jkbms_Brn:
         logger.debug("--> asy_connect_and_scrape(): connect and scrape on address: " + self.address)
         self.run = True
         while self.run and self.main_thread.is_alive():  # autoreconnect
-            self.bt_client = BleakClient(self.address)
+            self.bt_client = BleakClient(self.address, adapter=self.adapter)
             logger.debug("--> asy_connect_and_scrape(): btloop")
 
             try:
-                logger.info("|- Try to connect to Jkbms_Ble at " + self.address)
+                logger.info("|- Try to connect to Jkbms_Ble at " + self.address + " using " + (self.adapter or "default") + " adapter")
                 await self.bt_client.connect()  # default timeout 10s
                 logger.info("|- Device connected, check if it's really a JKBMS")
 

--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -57,7 +57,7 @@ class Jkbms_pb(Battery):
         # Set the current limits, populate cell count, etc
         # Return True if success, False for failure
         status_data = self.read_serial_data_jkbms_pb(self.command_settings, 300)
-        if status_data is False:
+        if not status_data:
             return False
 
         VolSmartSleep = unpack_from("<i", status_data, 6)[0] / 1000
@@ -175,7 +175,7 @@ class Jkbms_pb(Battery):
     def read_status_data(self):
         status_data = self.read_serial_data_jkbms_pb(self.command_status, 299)
         # check if connection success
-        if status_data is False:
+        if not status_data:
             return False
 
         #        logger.error("sucess we have data")
@@ -356,7 +356,7 @@ class Jkbms_pb(Battery):
             self.LENGTH_SIZE,  # ignored
             battery_online=self.online,
         )
-        if data is False:
+        if not data:
             return False
 
         # be = ''.join(format(x, ' 02X') for x in data)

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -124,15 +124,16 @@ CURRENT_MEASURED_BY_USER = -300, 300
 ; +++ For a stable connection, use the serial connection. +++
 ; +++ HCI selection is supported only by Jkbms_Ble. +++
 ; Description:
-;     Specify the Bluetooth BMS and its MAC address that you want to use. Optionally use  '@' to specify HCI name 
-;     to be used with the BMS. Leave empty to disable.
+;     Specify the Bluetooth BMS and its MAC address that you want to use. Optionally -  '@' to specify HCI name or 
+;     adapter MAC address to be used with the BMS. Leave empty to disable.
 ; Available Bluetooth BMS:
 ;     Jkbms_Ble, LiTime_Ble, LltJbd_Ble
 ; Example for one BMS:
 ;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00
 ;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00@hci1
+;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00@04:42:1A:00:00:11
 ; Example for multiple BMS:
-;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00, Jkbms_Ble C8:47:8C:00:00:11@hci1, Jkbms_Ble C8:47:8C:00:00:22
+;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00, Jkbms_Ble C8:47:8C:00:00:11@hci1, Jkbms_Ble C8:47:8C:00:00:22@@04:42:1A:00:00:11
 BLUETOOTH_BMS =
 
 ; Force to use polling instead of active callbacks.

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -122,14 +122,17 @@ CURRENT_MEASURED_BY_USER = -300, 300
 ; --------- Bluetooth BMS ---------
 ; +++ Bluetooth connections may be unstable on some systems. +++
 ; +++ For a stable connection, use the serial connection. +++
+; +++ HCI selection is supported only by Jkbms_Ble. +++
 ; Description:
-;     Specify the Bluetooth BMS and its MAC address that you want to use. Leave empty to disable.
+;     Specify the Bluetooth BMS and its MAC address that you want to use. Optionally use  '@' to specify HCI name 
+;     to be used with the BMS. Leave empty to disable.
 ; Available Bluetooth BMS:
 ;     Jkbms_Ble, LiTime_Ble, LltJbd_Ble
 ; Example for one BMS:
 ;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00
+;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00@hci1
 ; Example for multiple BMS:
-;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00, Jkbms_Ble C8:47:8C:00:00:11, Jkbms_Ble C8:47:8C:00:00:22
+;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00, Jkbms_Ble C8:47:8C:00:00:11@hci1, Jkbms_Ble C8:47:8C:00:00:22
 BLUETOOTH_BMS =
 
 ; Force to use polling instead of active callbacks.

--- a/dbus-serialbattery/dbus-serialbattery.py
+++ b/dbus-serialbattery/dbus-serialbattery.py
@@ -321,6 +321,7 @@ def main():
             exit_driver(None, None, 1)
         else:
             ble_address = sys.argv[2]
+            ble_adapter = sys.argv[3] if len(sys.argv) > 3 else None
 
             if port == "Jkbms_Ble":
                 # noqa: F401 --> ignore flake "imported but unused" error
@@ -347,7 +348,7 @@ def main():
             class_ = eval(port)
 
             # do not remove ble_ prefix, since the dbus service cannot be only numbers
-            testbms = class_("ble_" + ble_address.replace(":", "").lower(), 9600, ble_address)
+            testbms = class_("ble_" + ble_address.replace(":", "").lower(), 9600, ble_address, adapter=ble_adapter)
 
             if testbms.test_connection():
                 logger.info("-- Connection established to " + testbms.__class__.__name__)

--- a/dbus-serialbattery/enable.sh
+++ b/dbus-serialbattery/enable.sh
@@ -252,7 +252,7 @@ if [ "$bluetooth_length" -gt 0 ]; then
             exit 1
         fi
 
-        echo "Installing \"$2\" with MAC address \"$3\" as dbus-blebattery.$1"
+        echo "Installing \"$2\" with MAC address \"$3\" ${4:+using HCI $4} as dbus-blebattery.$1"
 
         mkdir -p "/service/dbus-blebattery.$1/log"
         {
@@ -272,7 +272,7 @@ if [ "$bluetooth_length" -gt 0 ]; then
             echo
             echo "# Start the main process"
             echo "exec 2>&1"
-            echo "python /data/apps/dbus-serialbattery/dbus-serialbattery.py $2 $3 &"
+            echo "python /data/apps/dbus-serialbattery/dbus-serialbattery.py $2 $3 $4 &"
             echo
             echo "# Capture the PID of the child process"
             echo "PID=\$!"
@@ -291,13 +291,14 @@ if [ "$bluetooth_length" -gt 0 ]; then
 
     # Example
     # install_blebattery_service 0 Jkbms_Ble C8:47:8C:00:00:00
-    # install_blebattery_service 1 Jkbms_Ble C8:47:8C:00:00:11
+    # install_blebattery_service 1 Jkbms_Ble C8:47:8C:00:00:11 hci1
+    # install_blebattery_service 1 Jkbms_Ble C8:47:8C:00:00:22 04:42:1A:00:00:11
 
     for (( i=0; i<bluetooth_length; i++ ));
     do
-        # split BMS type and MAC address
-        IFS=' ' read -r -a bms <<< "${bms_array[$i]}"
-        install_blebattery_service $i "${bms[0]}" "${bms[1]}"
+        # split BMS type, MAC address and adapter
+        IFS=' @' read -r -a bms <<< "${bms_array[$i]}"
+        install_blebattery_service $i "${bms[0]}" "${bms[1]}" "${bms[2]}"
     done
 
     echo

--- a/dbus-serialbattery/install.sh
+++ b/dbus-serialbattery/install.sh
@@ -50,7 +50,7 @@ function restore_config {
         if [ -d "/data/apps/dbus-serialbattery" ]; then
             mv /data/apps/dbus-serialbattery_config.ini.backup /data/apps/dbus-serialbattery/config.ini
             echo "Config.ini restored to /data/apps/dbus-serialbattery/config.ini"
-        # restore to driver < v2.0.0 (downlgrade)
+        # restore to driver < v2.0.0 (downgrade)
         elif [ -d "/data/etc/dbus-serialbattery" ]; then
             mv /data/apps/dbus-serialbattery_config.ini.backup /data/etc/dbus-serialbattery/config.ini
             echo "Config.ini restored to /data/etc/dbus-serialbattery/config.ini"
@@ -87,7 +87,7 @@ if [ -z "$1" ]; then
     latest_release_mrmanuel_stable=$(curl -s https://api.github.com/repos/mr-manuel/venus-os_dbus-serialbattery/releases/latest | sed -nE 's/.*"tag_name": "([^"]+)".*/\1/p')
 
     # mr-manuel beta
-    latest_release_mrmanuel_beta=$(curl -s https://api.github.com/repos/mr-manuel/venus-os_dbus-serialbattery/releases | sed -nE 's/.*"tag_name": "([^"]+)".*/\1/p' | head -n 1)
+    latest_release_mrmanuel_beta=$(curl -s https://api.github.com/repos/mr-manuel/venus-os_dbus-serialbattery/releases | sed -nE 's/.*"tag_name": "([^"]+(rc|beta))".*/\1/p' | head -n 1)
 
     # mr-manuel master branch
     latest_release_mrmanuel_nightly=$(curl -s https://raw.githubusercontent.com/mr-manuel/venus-os_dbus-serialbattery/master/dbus-serialbattery/utils.py | grep DRIVER_VERSION | awk -F'"' '{print "v" $2}')
@@ -113,7 +113,7 @@ if [ -z "$1" ]; then
 
 
     echo
-    PS3=$'\nSelect which version you want to install from m-rmanuel\'s repo and enter the corresponding number: '
+    PS3=$'\nSelect which version you want to install from mr-manuel\'s repo and enter the corresponding number: '
 
     # create list of versions
     version_list=(


### PR DESCRIPTION
For now only Raspberry PI can benefit from using different BT adapter by disabling default one. This MR adds ability to select adapter for BMS connection without messing in the the system settings so you can use two or more at the same time.

To use it suffix BMS address with `@hciN` or `@<ADAPTER_MAC>`.