### PR TITLE
Bugfix for SOC integer issue for Daly Can protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Changed: Use Bluetooth MAC address as unique identifier for all Bluetooth BMS by @mr-manuel
 * Changed: Use port and address as unique identifier is now available for all serial BMS by @mr-manuel
 * Changed: Use correct temperature sensors for Daly CAN BMS instead of min/max values by @lex2k0
+* Changed: Added integer conversion for Daly Can BMS Set SOC GUI method by @lex2k0
 
 ## v2.0.20250729
 

--- a/dbus-serialbattery/bms/daly_can.py
+++ b/dbus-serialbattery/bms/daly_can.py
@@ -508,7 +508,7 @@ class Daly_Can(Battery):
             return False
 
         data = bytearray(8)
-        pack_into(">Hxxxxxx", data, 0, self.soc_to_set * 10)
+        pack_into(">Hxxxxxx", data, 0, int(self.soc_to_set * 10))
 
         message = Message(arbitration_id=(0x161E0080 | (self.device_address << 8)), data=data)
         self.can_transport_interface.can_bus.send(message, timeout=0.2)


### PR DESCRIPTION
* Added integer conversion for the Daly Can protocol setting the SOC value over to the BMS
* Solves #394 