### PR TITLE
Fix wrong length calculation

### DIFF
--- a/dbus-serialbattery/bms/lltjbd_ble.py
+++ b/dbus-serialbattery/bms/lltjbd_ble.py
@@ -198,7 +198,7 @@ class LltJbd_Ble(LltJbd):
                 return
 
             length = data[self.LENGTH_POS]
-            if len(data) <= length + self.LENGTH_POS + 1:
+            if len(data) <= length + self.LENGTH_POS + 3:
                 return
             if not future.done():
                 future.set_result(data)


### PR DESCRIPTION
The length of the complete packet is positionOfLengthByte + valueOfLengthByte + twoBytesForCheckSum + sevenSevenByte. So the old formula missed the two checksum bytes.

Depending on the timing this could have led to incomplete packets. 