### PR TITLE
Bugfix: soc_reset_in_days usage in string is missing f qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Changed: Seplos BMS - Fix problems with unique identifier when daisy chained by @KoljaWindeler
 * Changed: Use Bluetooth MAC address as unique identifier for all Bluetooth BMS by @mr-manuel
 * Changed: Use port and address as unique identifier is now available for all serial BMS by @mr-manuel
+* Changed: Added integer conversion for Daly Can BMS Set SOC GUI method by @lex2k0
 
 ## v2.0.20250729
 


### PR DESCRIPTION
The string in the gui debug information is missing the f qualifier to sesolve the var soc_reset_in_days correctly.