### PR TITLE
Update the default battery address to the master for LltJbd_Up16s

### DIFF
--- a/dbus-serialbattery/dbus-serialbattery.py
+++ b/dbus-serialbattery/dbus-serialbattery.py
@@ -76,7 +76,7 @@ supported_bms_types = [
     {"bms": Jkbms_pb, "baud": 115200, "address": b"\x01"},
     {"bms": KS48100, "baud": 9600, "address": b"\x01"},
     {"bms": LltJbd, "baud": 9600, "address": b"\x00"},
-    {"bms": LltJbd_Up16s, "baud": 9600, "address": b"\x00"},
+    {"bms": LltJbd_Up16s, "baud": 9600, "address": b"\x01"},
     {"bms": Pace, "baud": 9600, "address": b"\x00"},
     {"bms": Renogy, "baud": 9600, "address": b"\x30"},
     {"bms": Renogy, "baud": 9600, "address": b"\xf7"},


### PR DESCRIPTION
This makes it easier for new users to get LltJbd_Up16s working, otherwise the driver won't connect if BATTERY_ADDRESSES is not specified in the config, since 0 is not a valid address.

Context: https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/422#issuecomment-4109972260