### PR TITLE
Bugfix/older devices history entry mismatch for duplicate entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@
 * Changed: Use Bluetooth MAC address as unique identifier for all Bluetooth BMS by @mr-manuel
 * Changed: Use correct temperature sensors for Daly CAN BMS instead of min/max values by @lex2k0
 * Changed: Use port and address as unique identifier is now available for all serial BMS by @mr-manuel
+* Changed: dbushelper.py - Ensure loading of newest battery data if more than one duplicate exists by @lex2k0
+* Changed: dbushelper.py - Reworked save settings methods by @lex2k0
 
 ## v2.0.20250729
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 * Changed: Added integer conversion for Daly Can BMS Set SOC GUI method by @lex2k0
 * Changed: Daly BMS & Daly CAN BMS: Fix high charge/discharge current alarm. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/378 by @mr-manuel
 * Changed: Daren 485 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
+* Changed: dbushelper.py - Ensure loading of newest battery data if more than one duplicate exists by @lex2k0
+* Changed: dbushelper.py - Reworked save settings methods by @lex2k0
+* Changed: Decoupled SOC Reset after x days from the need that the battery has to switch to bulk charge, thus after every x days are passed by there will be a bulk charge / top balancing by @lex2k0
 * Changed: Disabled BMS SOC alerts if `SOC_CALCULATION` is enabled. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/377 by @mr-manuel
 * Changed: Driver internals - Renamed callback variables/functions and added a better description by @mr-manuel
 * Changed: EG4-LL BMS - Added BMS configuration polling on startup to load cell/pack voltage, temperature, current, and SOC alarm thresholds from the BMS by @tuxntoast
@@ -82,7 +85,6 @@
 * Changed: Use Bluetooth MAC address as unique identifier for all Bluetooth BMS by @mr-manuel
 * Changed: Use correct temperature sensors for Daly CAN BMS instead of min/max values by @lex2k0
 * Changed: Use port and address as unique identifier is now available for all serial BMS by @mr-manuel
-* Changed: Decoupled SOC Reset after x days from the need that the battery has to switch to bulk charge, thus after every x days are passed by there will be a bulk charge / top balancing by @lex2k0
 
 ## v2.0.20250729
 

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -283,6 +283,8 @@ class DbusHelper:
         #     }
         # }
 
+        newest_last_seen = 0
+
         # loop through devices in dbus settings
         if "Settings" in settings_from_dbus and "Devices" in settings_from_dbus["Settings"]:
             for key, value in settings_from_dbus["Settings"]["Devices"].items():
@@ -295,14 +297,27 @@ class DbusHelper:
                     # check the unique identifier, if the battery was already connected once
                     # if so, get the last saved data
                     if "UniqueIdentifier" in value and value["UniqueIdentifier"] == self.bms_id:
-                        # set found_bms to true
-                        found_bms = True
-
+                        
                         # check if the battery has ClassAndVrmInstance set
+                        temp_instance = "Unknown"
                         if "ClassAndVrmInstance" in value and value["ClassAndVrmInstance"] != "":
-                            # get the instance from the object name
-                            device_instance = int(value["ClassAndVrmInstance"][value["ClassAndVrmInstance"].rfind(":") + 1 :])
-                            logger.info(f"Reconnected to previously identified battery with DeviceInstance: {device_instance}")
+                            temp_instance = int(value["ClassAndVrmInstance"][value["ClassAndVrmInstance"].rfind(":") + 1 :])
+                            logger.info(f"Found previously identified battery with DeviceInstance: {temp_instance}")
+
+                        # compare last seen timestamp
+                        device_last_seen = int(value["LastSeen"]) if "LastSeen" in value and value["LastSeen"] != "" else 0
+                        
+                        if device_last_seen < newest_last_seen:
+                            logger.info(f"--> Ignoring DeviceInstance {temp_instance} (Older instance)")
+                            continue
+                            
+                        # take data if it is the newest timestamp
+                        newest_last_seen = device_last_seen
+                        found_bms = True
+                        
+                        if temp_instance != "Unknown":
+                            device_instance = temp_instance
+                            logger.info(f"--> Loading values from DeviceInstance: {device_instance} (Newest instance)")
 
                         # check if the battery has AllowMaxVoltage set
                         if "AllowMaxVoltage" in value and value["AllowMaxVoltage"] != "":

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -297,7 +297,7 @@ class DbusHelper:
                     # check the unique identifier, if the battery was already connected once
                     # if so, get the last saved data
                     if "UniqueIdentifier" in value and value["UniqueIdentifier"] == self.bms_id:
-                        
+
                         # check if the battery has ClassAndVrmInstance set
                         temp_instance = "Unknown"
                         if "ClassAndVrmInstance" in value and value["ClassAndVrmInstance"] != "":
@@ -306,15 +306,15 @@ class DbusHelper:
 
                         # compare last seen timestamp
                         device_last_seen = int(value["LastSeen"]) if "LastSeen" in value and value["LastSeen"] != "" else 0
-                        
+
                         if device_last_seen < newest_last_seen:
                             logger.info(f"--> Ignoring DeviceInstance {temp_instance} (Older instance)")
                             continue
-                            
+
                         # take data if it is the newest timestamp
                         newest_last_seen = device_last_seen
                         found_bms = True
-                        
+
                         if temp_instance != "Unknown":
                             device_instance = temp_instance
                             logger.info(f"--> Loading values from DeviceInstance: {device_instance} (Newest instance)")
@@ -1651,7 +1651,9 @@ class DbusHelper:
                 logger.error(f"Failed to save MaxVoltageStartTime ({self.battery.max_voltage_start_time}).")
                 result = False
             else:
-                logger.debug(f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, after {self.battery.max_voltage_start_time}")
+                logger.debug(
+                    f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, after {self.battery.max_voltage_start_time}"
+                )
                 self.save_charge_details_last["max_voltage_start_time"] = self.battery.max_voltage_start_time
 
         if self.battery.soc_calc != self.save_charge_details_last["soc_calc"]:
@@ -1681,7 +1683,9 @@ class DbusHelper:
                 logger.error(f"Failed to save SocResetLastReached ({self.battery.soc_reset_last_reached}).")
                 result = False
             else:
-                logger.debug(f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, after {self.battery.soc_reset_last_reached}")
+                logger.debug(
+                    f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, after {self.battery.soc_reset_last_reached}"
+                )
                 self.save_charge_details_last["soc_reset_last_reached"] = self.battery.soc_reset_last_reached
 
         # copy history values

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -1625,54 +1625,64 @@ class DbusHelper:
         result = True
 
         if self.battery.allow_max_voltage != self.save_charge_details_last["allow_max_voltage"]:
-            result = result + self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "AllowMaxVoltage",
                 1 if self.battery.allow_max_voltage else 0,
             )
-            logger.debug(f"Saved AllowMaxVoltage. Before {self.save_charge_details_last['allow_max_voltage']}, " + f"after {self.battery.allow_max_voltage}")
-            self.save_charge_details_last["allow_max_voltage"] = self.battery.allow_max_voltage
+            if not save_ok:
+                logger.error(f"Failed to save AllowMaxVoltage ({self.battery.allow_max_voltage}).")
+                result = False
+            else:
+                logger.debug(f"Saved AllowMaxVoltage. Before {self.save_charge_details_last['allow_max_voltage']}, after {self.battery.allow_max_voltage}")
+                self.save_charge_details_last["allow_max_voltage"] = self.battery.allow_max_voltage
 
         if self.battery.max_voltage_start_time != self.save_charge_details_last["max_voltage_start_time"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "MaxVoltageStartTime",
                 (self.battery.max_voltage_start_time if self.battery.max_voltage_start_time is not None else ""),
             )
-            logger.debug(
-                f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, "
-                + f"after {self.battery.max_voltage_start_time}"
-            )
-            self.save_charge_details_last["max_voltage_start_time"] = self.battery.max_voltage_start_time
+            if not save_ok:
+                logger.error(f"Failed to save MaxVoltageStartTime ({self.battery.max_voltage_start_time}).")
+                result = False
+            else:
+                logger.debug(f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, after {self.battery.max_voltage_start_time}")
+                self.save_charge_details_last["max_voltage_start_time"] = self.battery.max_voltage_start_time
 
         if self.battery.soc_calc != self.save_charge_details_last["soc_calc"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "SocCalc",
                 self.battery.soc_calc,
             )
-            logger.debug(f"soc_calc written to dbus: {self.battery.soc_calc}")
-            self.save_charge_details_last["soc_calc"] = self.battery.soc_calc
+            if not save_ok:
+                logger.error(f"Failed to save SocCalc ({self.battery.soc_calc}).")
+                result = False
+            else:
+                logger.debug(f"Saved SocCalc. Before {self.save_charge_details_last['soc_calc']}, after {self.battery.soc_calc}")
+                self.save_charge_details_last["soc_calc"] = self.battery.soc_calc
 
         if self.battery.soc_reset_last_reached != self.save_charge_details_last["soc_reset_last_reached"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "SocResetLastReached",
                 self.battery.soc_reset_last_reached,
             )
-            logger.debug(
-                f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, "
-                + f"after {self.battery.soc_reset_last_reached}",
-            )
-            self.save_charge_details_last["soc_reset_last_reached"] = self.battery.soc_reset_last_reached
+            if not save_ok:
+                logger.error(f"Failed to save SocResetLastReached ({self.battery.soc_reset_last_reached}).")
+                result = False
+            else:
+                logger.debug(f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, after {self.battery.soc_reset_last_reached}")
+                self.save_charge_details_last["soc_reset_last_reached"] = self.battery.soc_reset_last_reached
 
         # copy history values
         history_values_dict = self.battery.history.__dict__.copy()
@@ -1688,17 +1698,19 @@ class DbusHelper:
 
         history_values = json.dumps(history_values_dict)
         if history_values != self.save_charge_details_last["history_values"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "HistoryValues",
                 history_values,
             )
-            logger.debug(
-                f"Saved HistoryValues. Before {self.save_charge_details_last['history_values']}, after {history_values}",
-            )
-            self.save_charge_details_last["history_values"] = history_values
+            if not save_ok:
+                logger.error("Failed to save HistoryValues.")
+                result = False
+            else:
+                logger.debug(f"Saved HistoryValues. Before {self.save_charge_details_last['history_values']}, after {history_values}")
+                self.save_charge_details_last["history_values"] = history_values
 
         return result
 

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -127,6 +127,7 @@ class DbusHelper:
             "history_values": "",
         }
         self.history_calculated_last_time: int = 0
+        self.settings_saved_last_time: int = 0
         """
         Last time the history values were calculated.
         """
@@ -1322,13 +1323,14 @@ class DbusHelper:
             logger.error("Non blocking exception occurred: " + f"{repr(exception_object)} of type {exception_type} in {file} line #{line}")
 
         # calculate history values every 60 seconds
-        if utils.HISTORY_ENABLE and int(time()) - self.history_calculated_last_time > 60:
+        if utils.HISTORY_ENABLE and int(time()) - self.history_calculated_last_time >= 60:
             self.battery.history_calculate_values()
             self.history_calculated_last_time = int(time())
 
         # save settings every 15 seconds to dbus
-        if int(time()) % 15 == 0:
+        if int(time()) - self.settings_saved_last_time >= 15:
             self.save_current_battery_state()
+            self.settings_saved_last_time = int(time())
 
         if self.battery.soc is not None:
             logger.debug("logged to dbus [%s]" % str(round(self.battery.soc, 2)))

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -317,7 +317,7 @@ class DbusHelper:
 
                         if temp_instance != "Unknown":
                             device_instance = temp_instance
-                            logger.info(f"--> Loading values from DeviceInstance: {device_instance} (Newest instance)")
+                            logger.info(f"--> Loading values from DeviceInstance: {device_instance} (Newer instance)")
 
                         # check if the battery has AllowMaxVoltage set
                         if "AllowMaxVoltage" in value and value["AllowMaxVoltage"] != "":

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -1626,54 +1626,64 @@ class DbusHelper:
         result = True
 
         if self.battery.allow_max_voltage != self.save_charge_details_last["allow_max_voltage"]:
-            result = result + self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "AllowMaxVoltage",
                 1 if self.battery.allow_max_voltage else 0,
             )
-            logger.debug(f"Saved AllowMaxVoltage. Before {self.save_charge_details_last['allow_max_voltage']}, " + f"after {self.battery.allow_max_voltage}")
-            self.save_charge_details_last["allow_max_voltage"] = self.battery.allow_max_voltage
+            if not save_ok:
+                logger.error(f"Failed to save AllowMaxVoltage ({self.battery.allow_max_voltage}).")
+                result = False
+            else:
+                logger.debug(f"Saved AllowMaxVoltage. Before {self.save_charge_details_last['allow_max_voltage']}, after {self.battery.allow_max_voltage}")
+                self.save_charge_details_last["allow_max_voltage"] = self.battery.allow_max_voltage
 
         if self.battery.max_voltage_start_time != self.save_charge_details_last["max_voltage_start_time"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "MaxVoltageStartTime",
                 (self.battery.max_voltage_start_time if self.battery.max_voltage_start_time is not None else ""),
             )
-            logger.debug(
-                f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, "
-                + f"after {self.battery.max_voltage_start_time}"
-            )
-            self.save_charge_details_last["max_voltage_start_time"] = self.battery.max_voltage_start_time
+            if not save_ok:
+                logger.error(f"Failed to save MaxVoltageStartTime ({self.battery.max_voltage_start_time}).")
+                result = False
+            else:
+                logger.debug(f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, after {self.battery.max_voltage_start_time}")
+                self.save_charge_details_last["max_voltage_start_time"] = self.battery.max_voltage_start_time
 
         if self.battery.soc_calc != self.save_charge_details_last["soc_calc"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "SocCalc",
                 self.battery.soc_calc,
             )
-            logger.debug(f"soc_calc written to dbus: {self.battery.soc_calc}")
-            self.save_charge_details_last["soc_calc"] = self.battery.soc_calc
+            if not save_ok:
+                logger.error(f"Failed to save SocCalc ({self.battery.soc_calc}).")
+                result = False
+            else:
+                logger.debug(f"Saved SocCalc. Before {self.save_charge_details_last['soc_calc']}, after {self.battery.soc_calc}")
+                self.save_charge_details_last["soc_calc"] = self.battery.soc_calc
 
         if self.battery.soc_reset_last_reached != self.save_charge_details_last["soc_reset_last_reached"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "SocResetLastReached",
                 self.battery.soc_reset_last_reached,
             )
-            logger.debug(
-                f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, "
-                + f"after {self.battery.soc_reset_last_reached}",
-            )
-            self.save_charge_details_last["soc_reset_last_reached"] = self.battery.soc_reset_last_reached
+            if not save_ok:
+                logger.error(f"Failed to save SocResetLastReached ({self.battery.soc_reset_last_reached}).")
+                result = False
+            else:
+                logger.debug(f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, after {self.battery.soc_reset_last_reached}")
+                self.save_charge_details_last["soc_reset_last_reached"] = self.battery.soc_reset_last_reached
 
         # copy history values
         history_values_dict = self.battery.history.__dict__.copy()
@@ -1689,17 +1699,19 @@ class DbusHelper:
 
         history_values = json.dumps(history_values_dict)
         if history_values != self.save_charge_details_last["history_values"]:
-            result = result and self.set_settings(
+            save_ok = self.set_settings(
                 get_bus("com.victronenergy.settings"),
                 "com.victronenergy.settings",
                 self.path_battery,
                 "HistoryValues",
                 history_values,
             )
-            logger.debug(
-                f"Saved HistoryValues. Before {self.save_charge_details_last['history_values']}, after {history_values}",
-            )
-            self.save_charge_details_last["history_values"] = history_values
+            if not save_ok:
+                logger.error("Failed to save HistoryValues.")
+                result = False
+            else:
+                logger.debug(f"Saved HistoryValues. Before {self.save_charge_details_last['history_values']}, after {history_values}")
+                self.save_charge_details_last["history_values"] = history_values
 
         return result
 

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -127,6 +127,7 @@ class DbusHelper:
             "history_values": "",
         }
         self.history_calculated_last_time: int = 0
+        self.settings_saved_last_time: int = 0
         """
         Last time the history values were calculated.
         """
@@ -1323,13 +1324,14 @@ class DbusHelper:
             logger.error("Non blocking exception occurred: " + f"{repr(exception_object)} of type {exception_type} in {file} line #{line}")
 
         # calculate history values every 60 seconds
-        if utils.HISTORY_ENABLE and int(time()) - self.history_calculated_last_time > 60:
+        if utils.HISTORY_ENABLE and int(time()) - self.history_calculated_last_time >= 60:
             self.battery.history_calculate_values()
             self.history_calculated_last_time = int(time())
 
         # save settings every 15 seconds to dbus
-        if int(time()) % 15 == 0:
+        if int(time()) - self.settings_saved_last_time >= 15:
             self.save_current_battery_state()
+            self.settings_saved_last_time = int(time())
 
         if self.battery.soc is not None:
             logger.debug("logged to dbus [%s]" % str(round(self.battery.soc, 2)))

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -297,7 +297,7 @@ class DbusHelper:
                     # check the unique identifier, if the battery was already connected once
                     # if so, get the last saved data
                     if "UniqueIdentifier" in value and value["UniqueIdentifier"] == self.bms_id:
-                        
+
                         # check if the battery has ClassAndVrmInstance set
                         temp_instance = "Unknown"
                         if "ClassAndVrmInstance" in value and value["ClassAndVrmInstance"] != "":
@@ -306,15 +306,15 @@ class DbusHelper:
 
                         # compare last seen timestamp
                         device_last_seen = int(value["LastSeen"]) if "LastSeen" in value and value["LastSeen"] != "" else 0
-                        
+
                         if device_last_seen < newest_last_seen:
                             logger.info(f"--> Ignoring DeviceInstance {temp_instance} (Older instance)")
                             continue
-                            
+
                         # take data if it is the newest timestamp
                         newest_last_seen = device_last_seen
                         found_bms = True
-                        
+
                         if temp_instance != "Unknown":
                             device_instance = temp_instance
                             logger.info(f"--> Loading values from DeviceInstance: {device_instance} (Newest instance)")
@@ -1652,7 +1652,9 @@ class DbusHelper:
                 logger.error(f"Failed to save MaxVoltageStartTime ({self.battery.max_voltage_start_time}).")
                 result = False
             else:
-                logger.debug(f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, after {self.battery.max_voltage_start_time}")
+                logger.debug(
+                    f"Saved MaxVoltageStartTime. Before {self.save_charge_details_last['max_voltage_start_time']}, after {self.battery.max_voltage_start_time}"
+                )
                 self.save_charge_details_last["max_voltage_start_time"] = self.battery.max_voltage_start_time
 
         if self.battery.soc_calc != self.save_charge_details_last["soc_calc"]:
@@ -1682,7 +1684,9 @@ class DbusHelper:
                 logger.error(f"Failed to save SocResetLastReached ({self.battery.soc_reset_last_reached}).")
                 result = False
             else:
-                logger.debug(f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, after {self.battery.soc_reset_last_reached}")
+                logger.debug(
+                    f"Saved SocResetLastReached. Before {self.save_charge_details_last['soc_reset_last_reached']}, after {self.battery.soc_reset_last_reached}"
+                )
                 self.save_charge_details_last["soc_reset_last_reached"] = self.battery.soc_reset_last_reached
 
         # copy history values


### PR DESCRIPTION
* Changed setup_instance() to be able to handle multiple instances of the same battery which lead to loading older data but store it to the newest device while driver is running.
* Changed save settings independent of modulo operator so it is working securly if POLL_INTERVAL is set
* Rework on save_current_battery_state() so one unsucessful settings trial is not stopping the following other settings from being stored.

Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/417