### PR TITLE
dbushelper: centralize Victron settings bus name; clarify get_bus

### DIFF
--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -18,6 +18,11 @@ from vedbus import VeDbusService  # noqa: E402
 from ve_utils import get_vrm_portal_id  # noqa: E402
 from settingsdevice import SettingsDevice  # noqa: E402
 
+# Victron settings service: D-Bus well-known name and the shared key for get_bus() so every
+# SettingsDevice / get_settings / set_settings call reuses one BusConnection (avoids leaks;
+# see #402) while each VeDbusService still uses its own connection (see #410).
+VICTRON_SETTINGS_DBUS_NAME = "com.victronenergy.settings"
+
 _SENTINEL = object()
 
 
@@ -74,8 +79,11 @@ class SessionBus(dbus.bus.BusConnection):
 _bus_instances = {}
 
 
-def get_bus(dbus_name) -> dbus.bus.BusConnection:
-    """Return a shared bus connection for the given service name, creating it if needed.
+def get_bus(dbus_name: str) -> dbus.bus.BusConnection:
+    """Return a shared bus connection for the given cache key, creating it if needed.
+
+    ``dbus_name`` is both the dict key in ``_bus_instances`` and, for peer services, the
+    well-known name you will talk to on that connection (e.g. ``VICTRON_SETTINGS_DBUS_NAME``).
 
     Note: VeDbusService registers D-Bus object paths (such as '/') and requires a unique bus connection per service instance.
     If multiple VeDbusService objects share the same connection, they will conflict when registering the same object path.
@@ -237,13 +245,13 @@ class DbusHelper:
         self.path_battery = "/Settings/Devices/serialbattery" + "_" + str(self.bms_id).upper()
 
         # prepare settings class
-        self.settings = SettingsDevice(get_bus("com.victronenergy.settings"), self.EMPTY_DICT, self.handle_changed_setting)
+        self.settings = SettingsDevice(get_bus(VICTRON_SETTINGS_DBUS_NAME), self.EMPTY_DICT, self.handle_changed_setting)
         logger.debug("setup_instance(): SettingsDevice")
 
         # get all the settings from the dbus
         settings_from_dbus = self.get_settings_with_values(
-            get_bus("com.victronenergy.settings"),
-            "com.victronenergy.settings",
+            get_bus(VICTRON_SETTINGS_DBUS_NAME),
+            VICTRON_SETTINGS_DBUS_NAME,
             "/Settings/Devices",
         )
         logger.debug("setup_instance(): get_settings_with_values")
@@ -377,8 +385,8 @@ class DbusHelper:
                     elif "LastSeen" in value and int(value["LastSeen"]) < int(time()) - (60 * 60 * 24 * 30):
                         # remove entry
                         del_return = self.remove_settings(
-                            get_bus("com.victronenergy.settings"),
-                            "com.victronenergy.settings",
+                            get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                            VICTRON_SETTINGS_DBUS_NAME,
                             "/Settings/Devices/" + key,
                             [
                                 "AllowMaxVoltage",
@@ -397,8 +405,8 @@ class DbusHelper:
                     # check if the battery has a last seen time, if not then it's an old entry and can be removed
                     elif "LastSeen" not in value:
                         del_return = self.remove_settings(
-                            get_bus("com.victronenergy.settings"),
-                            "com.victronenergy.settings",
+                            get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                            VICTRON_SETTINGS_DBUS_NAME,
                             "/Settings/Devices/" + key,
                             ["ClassAndVrmInstance"],
                         )
@@ -408,8 +416,8 @@ class DbusHelper:
                     # check if Ruuvi tag is enabled, if not remove entry.
                     if "Enabled" in value and value["Enabled"] == "0" and "ClassAndVrmInstance" not in value:
                         del_return = self.remove_settings(
-                            get_bus("com.victronenergy.settings"),
-                            "com.victronenergy.settings",
+                            get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                            VICTRON_SETTINGS_DBUS_NAME,
                             "/Settings/Devices/" + key,
                             ["CustomName", "Enabled", "TemperatureType"],
                         )
@@ -423,7 +431,7 @@ class DbusHelper:
         # create class and crm instance
         class_and_vrm_instance = "battery:" + str(device_instance)
 
-        # preare settings and write them to com.victronenergy.settings
+        # Prepare settings and write them to the Victron settings service (VICTRON_SETTINGS_DBUS_NAME).
         settings = {
             "AllowMaxVoltage": [
                 self.path_battery + "/AllowMaxVoltage",
@@ -486,8 +494,8 @@ class DbusHelper:
         # update last seen
         if found_bms:
             self.set_settings(
-                get_bus("com.victronenergy.settings"),
-                "com.victronenergy.settings",
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
                 self.path_battery,
                 "LastSeen",
                 int(time()),
@@ -1255,13 +1263,13 @@ class DbusHelper:
 
                     # Get settings from dbus
                     settings_battery_life = self.get_settings_with_values(
-                        get_bus("com.victronenergy.settings"),
-                        "com.victronenergy.settings",
+                        get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                        VICTRON_SETTINGS_DBUS_NAME,
                         "/Settings/CGwacs/BatteryLife",
                     )
                     settings_hub4mode = self.get_settings_with_values(
-                        get_bus("com.victronenergy.settings"),
-                        "com.victronenergy.settings",
+                        get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                        VICTRON_SETTINGS_DBUS_NAME,
                         "/Settings/CGwacs/Hub4Mode",
                     )
 
@@ -1551,8 +1559,8 @@ class DbusHelper:
         :return: The custom name if the operation was successful, otherwise None.
         """
         result = self.set_settings(
-            get_bus("com.victronenergy.settings"),
-            "com.victronenergy.settings",
+            get_bus(VICTRON_SETTINGS_DBUS_NAME),
+            VICTRON_SETTINGS_DBUS_NAME,
             self.path_battery,
             "CustomName",
             value,
@@ -1609,8 +1617,8 @@ class DbusHelper:
 
         if self.battery.allow_max_voltage != self.save_charge_details_last["allow_max_voltage"]:
             result = result + self.set_settings(
-                get_bus("com.victronenergy.settings"),
-                "com.victronenergy.settings",
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
                 self.path_battery,
                 "AllowMaxVoltage",
                 1 if self.battery.allow_max_voltage else 0,
@@ -1620,8 +1628,8 @@ class DbusHelper:
 
         if self.battery.max_voltage_start_time != self.save_charge_details_last["max_voltage_start_time"]:
             result = result and self.set_settings(
-                get_bus("com.victronenergy.settings"),
-                "com.victronenergy.settings",
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
                 self.path_battery,
                 "MaxVoltageStartTime",
                 (self.battery.max_voltage_start_time if self.battery.max_voltage_start_time is not None else ""),
@@ -1634,8 +1642,8 @@ class DbusHelper:
 
         if self.battery.soc_calc != self.save_charge_details_last["soc_calc"]:
             result = result and self.set_settings(
-                get_bus("com.victronenergy.settings"),
-                "com.victronenergy.settings",
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
                 self.path_battery,
                 "SocCalc",
                 self.battery.soc_calc,
@@ -1645,8 +1653,8 @@ class DbusHelper:
 
         if self.battery.soc_reset_last_reached != self.save_charge_details_last["soc_reset_last_reached"]:
             result = result and self.set_settings(
-                get_bus("com.victronenergy.settings"),
-                "com.victronenergy.settings",
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
                 self.path_battery,
                 "SocResetLastReached",
                 self.battery.soc_reset_last_reached,
@@ -1672,8 +1680,8 @@ class DbusHelper:
         history_values = json.dumps(history_values_dict)
         if history_values != self.save_charge_details_last["history_values"]:
             result = result and self.set_settings(
-                get_bus("com.victronenergy.settings"),
-                "com.victronenergy.settings",
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
                 self.path_battery,
                 "HistoryValues",
                 history_values,

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -18,9 +18,10 @@ from vedbus import VeDbusService  # noqa: E402
 from ve_utils import get_vrm_portal_id  # noqa: E402
 from settingsdevice import SettingsDevice  # noqa: E402
 
-# Victron settings service: D-Bus well-known name and the shared key for get_bus() so every
-# SettingsDevice / get_settings / set_settings call reuses one BusConnection (avoids leaks;
-# see #402) while each VeDbusService still uses its own connection (see #410).
+# Bus name Victron's settings daemon publishes on the system bus (D-Bus calls this a
+# "well-known" name: a fixed string both sides use, unlike unique :1.xx connection names).
+# Every DbusHelper uses this same peer; get_bus() caches one BusConnection for it (#402).
+# Each battery's VeDbusService uses a different name (_dbusname) and its own connection (#410).
 VICTRON_SETTINGS_DBUS_NAME = "com.victronenergy.settings"
 
 _SENTINEL = object()
@@ -82,11 +83,17 @@ _bus_instances = {}
 def get_bus(dbus_name: str) -> dbus.bus.BusConnection:
     """Return a shared bus connection for the given cache key, creating it if needed.
 
-    ``dbus_name`` is the dict key in ``_bus_instances`` and must match the D-Bus well-known
-    bus name for that connection: ``VICTRON_SETTINGS_DBUS_NAME`` for all settings I/O
-    (``SettingsDevice``, ``get_settings_with_values``, ``set_settings``, etc.), or
-    each ``DbusHelper`` instance's ``_dbusname`` for the ``BusConnection`` paired with that
-    battery's ``VeDbusService`` (one connection per exported battery service name).
+    ``dbus_name`` is the dict key in ``_bus_instances`` and must be the same fixed bus name
+    this code uses to reach the corresponding peer on D-Bus (freedesktop D-Bus spec:
+    ``well-known name``). Two cases:
+
+    * ``VICTRON_SETTINGS_DBUS_NAME`` — Victron exposes one settings service under this name;
+      all batteries are clients of that single peer, so all settings I/O in this process
+      correctly reuses one cached ``BusConnection``.
+    * Each ``DbusHelper``'s ``_dbusname`` — must be **unique per battery** this process
+      exports (port plus BMS address suffix when needed). That name must **not** be shared
+      across batteries: each ``VeDbusService`` needs its own ``BusConnection`` or object-path
+      registration on ``'/'`` collides (see #410).
 
     Note: VeDbusService registers D-Bus object paths (such as '/') and requires a unique bus connection per service instance.
     If multiple VeDbusService objects share the same connection, they will conflict when registering the same object path.

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -82,8 +82,11 @@ _bus_instances = {}
 def get_bus(dbus_name: str) -> dbus.bus.BusConnection:
     """Return a shared bus connection for the given cache key, creating it if needed.
 
-    ``dbus_name`` is both the dict key in ``_bus_instances`` and, for peer services, the
-    well-known name you will talk to on that connection (e.g. ``VICTRON_SETTINGS_DBUS_NAME``).
+    ``dbus_name`` is the dict key in ``_bus_instances`` and must match the D-Bus well-known
+    bus name for that connection: ``VICTRON_SETTINGS_DBUS_NAME`` for all settings I/O
+    (``SettingsDevice``, ``get_settings_with_values``, ``set_settings``, etc.), or
+    each ``DbusHelper`` instance's ``_dbusname`` for the ``BusConnection`` paired with that
+    battery's ``VeDbusService`` (one connection per exported battery service name).
 
     Note: VeDbusService registers D-Bus object paths (such as '/') and requires a unique bus connection per service instance.
     If multiple VeDbusService objects share the same connection, they will conflict when registering the same object path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,8 @@ _BusConnection = type(
         "TYPE_SYSTEM": 0,
         "TYPE_SESSION": 1,
         "__new__": lambda cls, *a, **kw: object.__new__(cls),
+        # dbushelper.get_bus() checks this; stub must not raise AttributeError in tests.
+        "get_is_connected": lambda self: True,
     },
 )
 

--- a/tests/test_get_bus.py
+++ b/tests/test_get_bus.py
@@ -5,7 +5,13 @@ when registering object path ``/``. The fix is to cache one connection per disti
 name (battery service name vs shared settings name). Full reproduction needs a live
 session/system bus and real ``VeDbusService``; these tests assert the caching contract
 that prevents regressing back to a single global connection for every name.
+
+PR #402: unbounded ``BusConnection`` creation (e.g. one per ``get_bus()`` call) leaks
+until the D-Bus daemon hits per-user limits. Tests that count ``SystemBus`` construction
+guard against regressions to a non-caching pattern for a given key.
 """
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,11 +19,18 @@ import dbushelper
 
 
 @pytest.fixture(autouse=True)
-def clear_bus_cache():
-    """Isolate tests from each other and from any prior imports."""
+def get_bus_test_isolation(monkeypatch):
+    """Use system-bus code path and clear the module cache between tests."""
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
     dbushelper._bus_instances.clear()
     yield
     dbushelper._bus_instances.clear()
+
+
+def _mock_bus():
+    m = MagicMock()
+    m.get_is_connected.return_value = True
+    return m
 
 
 class TestGetBusCache:
@@ -49,3 +62,53 @@ class TestGetBusCache:
         batt = dbushelper.get_bus("com.victronenergy.battery.can0__0x01")
         settings = dbushelper.get_bus(VICTRON_SETTINGS_DBUS_NAME)
         assert batt is not settings
+
+
+class TestGetBusConnectionLeak:
+    """Count real BusConnection constructors: must stay bounded per cache key (#402)."""
+
+    def test_many_get_bus_calls_one_system_bus_per_key(self):
+        """Same key many times → SystemBus() once (not once per call)."""
+        with patch.object(dbushelper, "SystemBus", side_effect=_mock_bus) as mock_sys:
+            for _ in range(100):
+                dbushelper.get_bus("com.victronenergy.settings")
+            assert mock_sys.call_count == 1
+
+    def test_distinct_keys_construct_distinct_buses(self):
+        """N keys touched once each → N SystemBus() calls, then cache hits only."""
+        names = [
+            "com.victronenergy.battery.ttyUSB0__0x01",
+            "com.victronenergy.battery.ttyUSB0__0x02",
+            "com.victronenergy.settings",
+        ]
+        with patch.object(dbushelper, "SystemBus", side_effect=_mock_bus) as mock_sys:
+            for n in names:
+                dbushelper.get_bus(n)
+            for _ in range(20):
+                dbushelper.get_bus(names[1])
+            assert mock_sys.call_count == len(names)
+
+    def test_disconnected_bus_is_replaced_once(self):
+        """If get_is_connected is false, get_bus allocates a fresh connection for that key."""
+        with patch.object(dbushelper, "SystemBus") as mock_sys_cls:
+            dead = MagicMock()
+            dead.get_is_connected.return_value = False
+            live = MagicMock()
+            live.get_is_connected.return_value = True
+            mock_sys_cls.side_effect = [dead, live]
+
+            first = dbushelper.get_bus("com.victronenergy.settings")
+            second = dbushelper.get_bus("com.victronenergy.settings")
+
+            assert first is dead
+            assert second is live
+            assert mock_sys_cls.call_count == 2
+
+    def test_many_calls_one_session_bus_per_key_when_session_env_set(self, monkeypatch):
+        """Same as system-bus case when DBUS_SESSION_BUS_ADDRESS selects SessionBus."""
+        monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/tmp/dbus-session-stub")
+        dbushelper._bus_instances.clear()
+        with patch.object(dbushelper, "SessionBus", side_effect=_mock_bus) as mock_sess:
+            for _ in range(80):
+                dbushelper.get_bus("com.victronenergy.settings")
+            assert mock_sess.call_count == 1

--- a/tests/test_get_bus.py
+++ b/tests/test_get_bus.py
@@ -1,0 +1,51 @@
+"""Regression tests for dbushelper.get_bus() cache behaviour.
+
+Issue #410: multiple ``VeDbusService`` instances on the *same* ``BusConnection`` collide
+when registering object path ``/``. The fix is to cache one connection per distinct bus
+name (battery service name vs shared settings name). Full reproduction needs a live
+session/system bus and real ``VeDbusService``; these tests assert the caching contract
+that prevents regressing back to a single global connection for every name.
+"""
+
+import pytest
+
+import dbushelper
+
+
+@pytest.fixture(autouse=True)
+def clear_bus_cache():
+    """Isolate tests from each other and from any prior imports."""
+    dbushelper._bus_instances.clear()
+    yield
+    dbushelper._bus_instances.clear()
+
+
+class TestGetBusCache:
+    def test_same_name_returns_same_connection(self):
+        """Repeated get_bus(name) must reuse one BusConnection (leak fix, #402)."""
+        a = dbushelper.get_bus("com.victronenergy.battery.ttyUSB0__0x01")
+        b = dbushelper.get_bus("com.victronenergy.battery.ttyUSB0__0x01")
+        assert a is b
+
+    def test_distinct_battery_names_get_distinct_connections(self):
+        """Each battery service name must have its own connection (#410)."""
+        first = dbushelper.get_bus("com.victronenergy.battery.ttyUSB0__0x01")
+        second = dbushelper.get_bus("com.victronenergy.battery.ttyUSB0__0x02")
+        assert first is not second
+
+    def test_settings_constant_matches_literal_for_cache(self):
+        """Settings I/O must share one cached connection under VICTRON_SETTINGS_DBUS_NAME."""
+        from dbushelper import VICTRON_SETTINGS_DBUS_NAME
+
+        assert VICTRON_SETTINGS_DBUS_NAME == "com.victronenergy.settings"
+        via_const = dbushelper.get_bus(VICTRON_SETTINGS_DBUS_NAME)
+        via_literal = dbushelper.get_bus("com.victronenergy.settings")
+        assert via_const is via_literal
+
+    def test_battery_connection_not_settings_connection(self):
+        """A battery export must not share the settings cache entry."""
+        from dbushelper import VICTRON_SETTINGS_DBUS_NAME
+
+        batt = dbushelper.get_bus("com.victronenergy.battery.can0__0x01")
+        settings = dbushelper.get_bus(VICTRON_SETTINGS_DBUS_NAME)
+        assert batt is not settings


### PR DESCRIPTION
## Summary

Follow-up after per-service `get_bus(dbus_name)` ([issue #410](https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/410), [PR #402](https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/402)):

- Add `VICTRON_SETTINGS_DBUS_NAME` so `com.victronenergy.settings` is not repeated across every `get_bus` / settings helper call (same string is both the **connection cache key** and the **D-Bus service name** Victron’s settings daemon uses).
- Type-hint `get_bus(dbus_name: str)` and expand the docstring: D-Bus spec **well-known name**, when the settings name is intentionally shared across all helpers vs when each battery needs a distinct `_dbusname` / connection.
- Fix a comment typo (`preare` → `prepare`).

No runtime behaviour change.

Does **not** address [issue #417](https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/417) (stale SOC / duplicate device entries); that is [PR #429](https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/429).

## Coordination with PR #429

[PR #429](https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/429) also edits `dbus-serialbattery/dbushelper.py` (`save_current_battery_state`, save cadence, duplicate `UniqueIdentifier` handling). Merge order only needs a small mechanical follow-up:

- **If #429 merges first:** I will rebase this branch on `master` and replace any new `"com.victronenergy.settings"` literals with `VICTRON_SETTINGS_DBUS_NAME` / `get_bus(VICTRON_SETTINGS_DBUS_NAME)` in the #429 changes.
- **If this PR merges first:** #429 should be rebased on `master` and the same substitution applied in the touched regions (no logic change).

Optional: I can push a commit to the #429 branch with only those substitutions if that helps.

@mr-manuel @lex2k0

## Cross-links

Pointers to this PR were added in: [#410 (comment)](https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/410#issuecomment-4202577974), [#417 (comment)](https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/417#issuecomment-4202578074), [#429 (comment)](https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/429#issuecomment-4202578175), [#402 (comment)](https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/402#issuecomment-4202578370).
