### PR TITLE
fix: guard cell voltage Diff calculation against None on BMS disconnect

### DIFF
--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -1206,10 +1206,9 @@ class DbusHelper:
                         voltage_sum += voltage
                 pathbase = "Cell" if (utils.BATTERY_CELL_DATA_FORMAT & 2) else "Voltages"
                 self._dbusservice["/%s/Sum" % pathbase] = round(voltage_sum, 2)
-                self._dbusservice["/%s/Diff" % pathbase] = round(
-                    self.battery.get_max_cell_voltage() - self.battery.get_min_cell_voltage(),
-                    3,
-                )
+                cell_max = self.battery.get_max_cell_voltage()
+                cell_min = self.battery.get_min_cell_voltage()
+                self._dbusservice["/%s/Diff" % pathbase] = round(cell_max - cell_min, 3) if cell_max is not None and cell_min is not None else None
             except Exception:
                 # set error code, to show in the GUI that something is wrong
                 self.battery.manage_error_code(8)


### PR DESCRIPTION
```markdown
## Problem

When `BATTERY_CELL_DATA_FORMAT > 0` is set and a BMS temporarily loses its
RS485 connection, the following error appears in the log on every reconnect cycle:

```
INFO:SerialBattery:  |- No battery recognized
ERROR:SerialBattery:Non blocking exception occurred: TypeError("unsupported operand type(s) for -: 'NoneType' and 'NoneType'") of type <class 'TypeError'> in /data/apps/dbus-serialbattery/dbushelper.py line #1251
```

## Root Cause

On disconnect, `init_values()` is called which resets all cell voltages to `None`.
Both `get_max_cell_voltage()` and `get_min_cell_voltage()` are declared as
`Union[float, None]` and correctly return `None` when no cell voltages are
available. However, the `Diff` calculation in `dbushelper.py` performs the
subtraction without a `None` check:

```python
self._dbusservice["/%s/Diff" % pathbase] = round(
    self.battery.get_max_cell_voltage() - self.battery.get_min_cell_voltage(),
    3,
)
```

`None - None` raises `TypeError`, which falls through to the broad `except
Exception` handler — triggering `manage_error_code(8)` and logging a
misleading error on every single reconnect.

## Fix

Extract both values first and guard the subtraction with an explicit `None`
check. Write `None` to dbus when voltages are unavailable, which is the
correct representation of "data not yet available".

## Testing

Reproduced with JKBMS on RS485 with `BATTERY_CELL_DATA_FORMAT = 1`.
Error disappeared after the fix. Normal operation (with valid cell voltages)
unaffected.
```
