### PR TITLE
Fix JK-BMS heater current calculation

### DIFF
--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -321,7 +321,7 @@ class Jkbms_pb(Battery):
         self.heating = 1 if heat != 0 else 0
 
         # HeatCurrent is provided in mA, convert to A
-        self.heater_current = int(unpack_from("<H", status_data, 236)[0]) / 1000
+        self.heater_current = int(unpack_from("<h", status_data, 236)[0]) / 1000
         self.heater_power = 0.0 if self.heating != 1 else float(self.heater_current * self.voltage)
 
         # show wich cells are balancing


### PR DESCRIPTION
This PR fixes the incorrect heater current reading for JK-BMS. Previously, the value was interpreted as an unsigned integer, leading to massive positive values (e.g., 61.2A) 
when the heater was actually drawing negative current of -4.3A.

* Signed Interpretation (<h): Changed from `<H` to `<h`.  
   The heater current in the JK protocol is a signed 16-bit integer (INT16). 
   See: https://gitlab.stn.pl/picoides-monitor/bms/jk-bms/-/blob/main/docs/%E6%9E%81%E7%A9%BABMS%20RS485%20Modbus%E9%80%9A%E7%94%A8%E5%8D%8F%E8%AE%AEV1.1%20-%20Jikong%20BMS%20RS485%20Modbus%20Universal%20Protocol%20V1.1%20EN.txt?ref_type=heads#L219 
   This correctly shows negative values when the battery is being discharged by the heater.

Fixes: #421

---

[On GUI](https://github.com/user-attachments/assets/a1d616a7-5320-4d0b-b4a4-e38668fa72e8)

---

[On dbus-spy](https://github.com/user-attachments/assets/231ff40c-03c1-465b-869b-3fd0b992710c)
