### PR TITLE
Fixes for startup scripts and JKBMS robustness during reconnect/restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * Changed: Mechanism to reset SOC via GUI, since it was not possible to set the same SOC twice by @mr-manuel
 * Changed: RV-C CAN BMS - Fixed wrong charge/discharge fet assignment @mr-manuel
 * Changed: Seplos BMS - Fix problems with unique identifier when daisy chained by @KoljaWindeler
+* Changed: Service runscripts now derive the serial port name from the service-directory suffix, so manually-created service entries (e.g. for socat-bridged PTYs) no longer depend on the `TTY` sentinel substitution by serial-starter. Fixes https://github.com/hsteinhaus/venus-os_dbus-serialbattery/issues/2 by @hsteinhaus
 * Changed: UBMS CAN code style to snake_case, various improvements and fixes by @gimx
 * Changed: Use Bluetooth MAC address as unique identifier for all Bluetooth BMS by @mr-manuel
 * Changed: Use correct temperature sensors for Daly CAN BMS instead of min/max values by @lex2k0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Changed: Daren 485 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
 * Changed: Disabled BMS SOC alerts if `SOC_CALCULATION` is enabled. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/377 by @mr-manuel
 * Changed: Driver internals - Renamed callback variables/functions and added a better description by @mr-manuel
+* Changed: D-bus charge limits - Skip None writes to `/Info/MaxChargeCurrent` and `/Info/MaxDischargeCurrent` so consumers like `dbus-aggregate-batteries` don't crash with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'` during the brief window before the first charge-control decision lands by @hsteinhaus
 * Changed: EG4-LL BMS - Added BMS configuration polling on startup to load cell/pack voltage, temperature, current, and SOC alarm thresholds from the BMS by @tuxntoast
 * Changed: EG4-LL BMS - Added CRC-16 checksum validation for all BMS reply frames by @tuxntoast
 * Changed: EG4-LL BMS - Added EG4AlarmManager class for threshold-based alarm evaluation with charge/discharge FET control by @tuxntoast
@@ -55,6 +56,7 @@
 * Changed: EG4-LL BMS - Improved serial port retry logic with automatic port recovery on SerialException by @tuxntoast
 * Changed: EG4-LL BMS - Improved startup log clarity by suppressing expected CH341 serial errors and retry messages to DEBUG level during the connection settling window by @tuxntoast
 * Changed: EG4-LL BMS - Improved USB-RS485 (CH341) connection reliability on startup by keeping the serial port open between retry attempts, adding a 60-second connection timeout loop, and disabling DTR/RTS hardware flow control to prevent adapter resets by @tuxntoast
+* Changed: enable.sh - Skip the unconditional kill cycle when invoked from `rc.local` with `--boot`, preventing a ~30 s outage at boot that broke downstream consumers like `dbus-aggregate-batteries` which poll dbus once at startup by @hsteinhaus
 * Changed: Exit behavior for excluded devices to behave like Victron services by @mr-manuel
 * Changed: Fix dbus connection leak which fixes problems on systems which multiple batteries with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/402 by @cgoudie
 * Changed: Fix issue with published JsonData, where None values were published as empty strings by @mr-manuel
@@ -68,6 +70,7 @@
 * Changed: JK Inverter BMS - Fixed serial number lenght by @mr-manuel
 * Changed: JKBMS BLE - Fixed negative temperature display. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/369 by @mr-manuel
 * Changed: JKBMS CAN - Correct calculation of arbitration_id for device_address > 0. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/288 with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/306 by @Hooorny
+* Changed: JKBMS PB - Auto-recover the shared RS485 port when the driver gets stuck after a USB re-plug or a persistent dead-bus: after 8 consecutive failed reads the fd is closed and reopened on next access by @hsteinhaus
 * Changed: JKBMS PB: Alarms were not set correctly @mr-manuel
 * Changed: KS48100 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
 * Changed: LLT/JBD BLE BMS - Fixed wrong charge/discharge fet assignment @mr-manuel

--- a/bms-docs/JKBMS-PB.md
+++ b/bms-docs/JKBMS-PB.md
@@ -748,6 +748,39 @@ publishes ~100 properties per cycle. Mitigations:
 2. **Poll interval decoupling**: auto-increase logic uses serial+calc
    time only, excluding D-Bus overhead.
 
+### Custom serial port (PTY / network bridge)
+
+Serial-starter only auto-spawns the driver for ports it discovers via
+udev (USB serials). To run on a `socat`-bridged PTY or any other
+non-USB port, register a manual service entry. The runscripts derive
+the port name from the service-directory suffix, so no template
+rewriting is needed.
+
+```sh
+# 1. Create the PTY (example: Waveshare RS485↔TCP server at <host>:<port>)
+socat -d pty,link=/dev/ttyV0,raw,echo=0,b115200,user=root,group=dialout,mode=0660 \
+      tcp:<host>:<port> &
+
+# 2. Create a permanent service entry under /data/
+PORT=ttyV0
+SVC=/data/etc/dbus-serialbattery-custom/dbus-serialbattery.$PORT
+mkdir -p "$SVC/log"
+cp /data/apps/dbus-serialbattery/service/run     "$SVC/run"
+cp /data/apps/dbus-serialbattery/service/log/run "$SVC/log/run"
+ln -sf "$SVC" "/service/dbus-serialbattery.$PORT"
+
+# 3. Persist across reboot (Venus wipes /service/ symlinks)
+echo "ln -sf $SVC /service/dbus-serialbattery.$PORT" >> /data/rc.local
+```
+
+Verify on D-Bus: `com.victronenergy.battery.<port>__<addr>` per
+battery, e.g. `com.victronenergy.battery.ttyV0__0x01`.
+
+`socat` lifecycle is the user's responsibility — supervise it with
+your tool of choice. If `/dev/$PORT` is missing when runit picks the
+service up, the runscript exits and the service stays down until
+socat is up and `svc -u /service/dbus-serialbattery.$PORT` is run.
+
 ## Reference Documents
 
 - "极空BMS RS485 Modbus通用协议(V1.0)" — `JK_BMS.RS485.Modbus.v1_0.pdf`

--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -41,6 +41,11 @@ class Jkbms_pb(Battery):
 
     _last_command_time = 0.0
     _timing_logged = False
+    _consecutive_failures = 0
+    # Recycle the shared port after this many consecutive failed reads. pyserial
+    # leaves is_open=True after a USB device disappears, so without this the
+    # driver keeps reusing a stale fd indefinitely.
+    _RECYCLE_THRESHOLD = 8
 
     @property
     def addr_str(self):
@@ -52,12 +57,29 @@ class Jkbms_pb(Battery):
             Jkbms_pb._shared_ser = serial.Serial(self.port, baudrate=self.baud_rate, timeout=0.1)
         return Jkbms_pb._shared_ser
 
+    def _recycle_port(self):
+        """Force the next _get_ser() to reopen the port (e.g. after USB re-plug)."""
+        logger.warning(f"[{self.addr_str}] recycling serial port after {Jkbms_pb._consecutive_failures} consecutive failures")
+        try:
+            if Jkbms_pb._shared_ser is not None:
+                Jkbms_pb._shared_ser.close()
+        except Exception:
+            pass
+        Jkbms_pb._shared_ser = None
+        Jkbms_pb._consecutive_failures = 0
+
     def _read_with_retry(self, ser, command, timeout=0.5):
         """Send command and read response, retry once on failure."""
         result = self._read_response(ser, command, timeout)
         if not result:
             logger.warning(f"[{self.addr_str}] retry: {command[1:5].hex()}")
             result = self._read_response(ser, command, timeout)
+        if result:
+            Jkbms_pb._consecutive_failures = 0
+        else:
+            Jkbms_pb._consecutive_failures += 1
+            if Jkbms_pb._consecutive_failures >= Jkbms_pb._RECYCLE_THRESHOLD:
+                self._recycle_port()
         return result
 
     def test_connection(self):

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -1142,9 +1142,14 @@ class DbusHelper:
             else None
         )
 
-        # Charge control
-        self._dbusservice["/Info/MaxChargeCurrent"] = self.battery.control_charge_current
-        self._dbusservice["/Info/MaxDischargeCurrent"] = self.battery.control_discharge_current
+        # Charge control. Skip None writes so consumers like dbus-aggregate-batteries
+        # that arithmetic on these paths don't crash on transient None during startup
+        # or a dead-bus window. The initial value set at add_path() (static configured
+        # maximum) stays in place until manage_charge_and_discharge_current() runs.
+        if self.battery.control_charge_current is not None:
+            self._dbusservice["/Info/MaxChargeCurrent"] = self.battery.control_charge_current
+        if self.battery.control_discharge_current is not None:
+            self._dbusservice["/Info/MaxDischargeCurrent"] = self.battery.control_discharge_current
 
         # Voltage and charge control info (custom dbus paths)
         self._dbusservice["/Info/ChargeMode"] = self.battery.charge_mode

--- a/dbus-serialbattery/enable.sh
+++ b/dbus-serialbattery/enable.sh
@@ -113,9 +113,15 @@ if [ ! -f "$filename" ]; then
     chmod 755 "$filename"
 fi
 
-# add enable script to rc.local
+# add enable script to rc.local with --boot flag, so the boot run can skip
+# the unconditional kill cycle that would otherwise tear down the freshly-started
+# BMS service ~30 s after it first comes up.
 # log the output to a file and run it in the background to prevent blocking the boot process
-grep -qxF "bash /data/apps/dbus-serialbattery/enable.sh > /data/apps/dbus-serialbattery/startup.log 2>&1 &" $filename || echo "bash /data/apps/dbus-serialbattery/enable.sh > /data/apps/dbus-serialbattery/startup.log 2>&1 &" >> $filename
+old_rclocal_line="bash /data/apps/dbus-serialbattery/enable.sh > /data/apps/dbus-serialbattery/startup.log 2>&1 &"
+new_rclocal_line="bash /data/apps/dbus-serialbattery/enable.sh --boot > /data/apps/dbus-serialbattery/startup.log 2>&1 &"
+# remove the previous (unflagged) entry if present
+sed -i "\|^${old_rclocal_line}\$|d" "$filename"
+grep -qxF "$new_rclocal_line" "$filename" || echo "$new_rclocal_line" >> "$filename"
 
 
 
@@ -139,18 +145,25 @@ fi
 
 
 
-# stop all dbus-serialbattery services, if at least one exists
-echo "Stop all dbus-serialbattery services..."
-for service in /service/dbus-serialbattery.*; do
-    [ -e "$service" ] && svc -d "$service"
-done
+# Stop all dbus-serialbattery services unless we were invoked from rc.local with
+# --boot. Boot-time invocations must not kill the freshly-started driver: that
+# causes a ~30 s outage which breaks downstream consumers like
+# dbus-aggregate-batteries (which polls dbus once at startup).
+if [ "${1:-}" = "--boot" ]; then
+    echo "Boot invocation — leaving any already-supervised dbus-serialbattery alone."
+else
+    echo "Stop all dbus-serialbattery services..."
+    for service in /service/dbus-serialbattery.*; do
+        [ -e "$service" ] && svc -d "$service"
+    done
 
-sleep 1
+    sleep 1
 
-# kill driver, if still running
-pkill -f "supervise dbus-serialbattery.*"
-pkill -f "multilog .* /var/log/dbus-serialbattery.*"
-pkill -f "python .*/dbus-serialbattery.py /dev/tty.*"
+    # kill driver, if still running
+    pkill -f "supervise dbus-serialbattery.*"
+    pkill -f "multilog .* /var/log/dbus-serialbattery.*"
+    pkill -f "python .*/dbus-serialbattery.py /dev/tty.*"
+fi
 
 
 

--- a/dbus-serialbattery/service/log/run
+++ b/dbus-serialbattery/service/log/run
@@ -1,3 +1,6 @@
 #!/bin/sh
 exec 2>&1
-exec multilog t s500000 n4 /var/log/dbus-serialbattery.TTY
+LOG_DIR="$(dirname "$(readlink -f "$0")")"
+SVC_DIR="${LOG_DIR%/log}"
+PORT_NAME="${SVC_DIR##*/dbus-serialbattery.}"
+exec multilog t s500000 n4 "/var/log/dbus-serialbattery.$PORT_NAME"

--- a/dbus-serialbattery/service/run
+++ b/dbus-serialbattery/service/run
@@ -3,9 +3,15 @@
 # Forward signals to the child process
 trap 'kill -TERM $PID' TERM INT
 
+# Derive port name from the service directory (dbus-serialbattery.<port>).
+# Lets manually-created service entries (e.g. for PTYs) work without depending
+# on serial-starter's template-rewriting step.
+SVC_DIR="$(dirname "$(readlink -f "$0")")"
+PORT_NAME="${SVC_DIR##*/dbus-serialbattery.}"
+
 # Start the main process
 exec 2>&1
-exec bash /data/apps/dbus-serialbattery/start-serialbattery.sh TTY &
+exec bash /data/apps/dbus-serialbattery/start-serialbattery.sh "$PORT_NAME" &
 
 # Capture the PID of the child process
 PID=$!


### PR DESCRIPTION
While testing locally and together with Andy @Off-Grid-Garage , we have disovered a couple of strange effects on latest master:
1. dbus-serialbattery is always started, then terminated, then started again during system boot. This process takes long enough on my  Cerbo to sound the alarm horn and to send a VRM alarm emails, which both is not really desirable for a just a reboot
2. I have observed a dead JKBMS bus on some of these start-kill-start cycles on my system (4 JKBMS PB batteries)
3. Andy has observed hangs during normal operation as well (I didn't)
4. Andy and I have observed hangs when unplugging and re-plugging the USB-RS485 adapter
5. I have seen dbus-aggregate-batteries being confused on one of the start-kill-start cycles due to None values being sent via DBus

See commit msgs and changelog for details on the single changes. The --boot parameter to enable.sh might be some kind of a breaking change for existing systems. I am open for alternative ideas, or to implement some kind of migration mechanism.

@Off-Grid-Garage : If I forgot something, please comment.