### PR TITLE
Change JKBMS product name to include battery and interface name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Added: JBD CAN protocol support with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/363 by @dmitrych5
 * Added: JBD UP16S series support, including daisy-chaining, with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/375 by @dmitrych5
 * Added: JK Inverter BMS - Heating informations with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/367 by @BitSeb
+* Changed: Default ProductName now includes the BMS unique identifier and the serial-port basename (e.g. `SerialBattery BB02 @ ttyUSB0 (JKBMS PB Model)`) so the GUI label tracks the current port across USB renumbering; the default CustomName is left empty so it acts as a pure user-override slot. Applies to any BMS class that does not override `custom_name()` / `product_name()` by @hsteinhaus
 * Added: JKBMS PB - Multi-battery RS485 fix for fw >= v15.36 with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/425 by @hsteinhaus
 * Added: JKBMS PB - Performance and stability improvements with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/428 by @hsteinhaus
 * Added: KS48100 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * Changed: Fixed problems with the `BLOCK_ON_DISCONNECT` behavior. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/309 by @mr-manuel
 * Changed: Fixed SOC manual reset via GUI having no effect when `SOC_CALCULATION` is enabled by @mr-manuel
 * Changed: Fixed typo in activation instructions by @mr-manuel
+* Changed: GUI clearing of CustomName was silently ignored — `callback_custom_name` returned the new value, which is falsy for the empty string and caused VeDbusService to reject the write while `set_settings` had already persisted it; callback now returns truthy on success by @hsteinhaus
 * Changed: Guard voltage and current limit assignments with `USE_BMS_DVCC_VALUES`; replace hardcoded limits with `MAX_CELL_VOLTAGE`, `MAX_BATTERY_CHARGE_CURRENT`, and `MAX_BATTERY_DISCHARGE_CURRENT` config constants. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/454 by @mr-manuel
 * Changed: GUIv2 - With Venus OS `v3.80~21` GUIv2 plugins are used instead of fully customized GUI by @mr-manuel
 * Changed: GUIv2: Add cell diff to mean and improve calculations to reduce CPU load. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/360 by @mr-manuel

--- a/dbus-serialbattery/battery.py
+++ b/dbus-serialbattery/battery.py
@@ -486,20 +486,27 @@ class Battery(ABC):
 
     def custom_name(self) -> str:
         """
-        Shown in the GUI under `Device -> Name`
-        Overwritten, if the user set a custom name via GUI
+        Shown in the GUI under `Device -> Name`. Empty by default so the GUI
+        falls back to ProductName (which is dynamic per boot). User-typed
+        names from the GUI are persisted by dbushelper.callback_custom_name
+        and override this default.
 
-        :return: the connection name
+        :return: the custom name (empty unless a subclass overrides)
         """
-        return "SerialBattery(" + self.type + ")"
+        return ""
 
     def product_name(self) -> str:
         """
-        Shown in the GUI under `Device -> Product`
+        Shown in the GUI under `Device -> Product`. Combines the BMS unique
+        identifier and the serial-port basename so the label stays
+        informative across USB renumbering. Subclasses can override if the
+        port is not a /dev path (e.g. BLE, MQTT).
 
-        :return: the connection name
+        :return: the product name
         """
-        return "SerialBattery(" + self.type + ")"
+        uid = self.unique_identifier()
+        iface = self.port.rsplit("/", 1)[-1] if self.port else ""
+        return f"SerialBattery {uid} @ {iface} ({self.type})"
 
     def use_callback(self, callback: Callable) -> bool:
         """

--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -434,9 +434,11 @@ class Jkbms_pb(Battery):
 
     def unique_identifier(self) -> str:
         """
-        Used to identify a BMS when multiple BMS are connected
+        Used to identify a BMS when multiple BMS are connected. Falls back
+        to the bus address (each BMS on the RS485 bus has a unique one)
+        until the serial number is parsed from the 'about' frame.
         """
-        return self.unique_identifier_tmp
+        return self.unique_identifier_tmp or ("0x" + self.address.hex())
 
     def get_balancing(self):
         return 1 if self.balancing else 0

--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -287,7 +287,7 @@ class Jkbms_pb(Battery):
 
             ODDRunTime = unpack_from("<I", status_data, 38)[0]  # 1 unit32 # runtime of the system in seconds
             PWROnTimes = unpack_from("<I", status_data, 42)[0]  # 1 unit32 # how many startups the system has done
-            serial_nr = status_data[46:61].decode("utf-8").split("\x00", 1)[0]  # serialnumber 16 chars max
+            serial_nr = status_data[46:61].decode("utf-8").split("\x00", 1)[0].strip()  # serialnumber 16 chars max
             usrData = status_data[102:117].decode("utf-8").split("\x00", 1)[0]  # usrData 16 chars max
             pin = status_data[118:133].decode("utf-8").split("\x00", 1)[0]  # pin 16 chars max
             usrData2 = status_data[134:149].decode("utf-8").split("\x00", 1)[0]  # usrData 2 16 chars max

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -1672,7 +1672,11 @@ class DbusHelper:
             value,
         )
         logger.debug(f'CustomName changed to "{value}" for {self.path_battery}: {result}')
-        return value if result else None
+        # Return truthy on success: VeDbusService.SetValue checks the callback
+        # return in boolean context, so returning ``value`` would reject empty
+        # strings (user clearing the field) even though set_settings persisted
+        # them. See ext/velib_python/vedbus.py:578.
+        return True if result else None
 
     def callback_soc_reset_to(self, path, value) -> int:
         """

--- a/tests/bms/test_jkbms_pb.py
+++ b/tests/bms/test_jkbms_pb.py
@@ -228,3 +228,42 @@ class TestReadResponse:
         assert result is not False
         assert len(result) == 300
         assert result[4] | result[5] << 8 == 1  # ftype=1 = settings
+
+
+class TestNaming:
+    """ProductName carries dynamic serial+interface info (base-class default
+    in battery.py); CustomName is a pure user-override slot (empty by
+    default). jkbms_pb only overrides ``unique_identifier`` to provide the
+    address fallback until the serial number is parsed.
+    """
+
+    def _bms(self, addr=0x03, port="/dev/ttyUSB0", serial=""):
+        bms = _make_bms(addr=addr)
+        bms.port = port
+        bms.type = Jkbms_pb.BATTERYTYPE
+        bms.unique_identifier_tmp = serial
+        return bms
+
+    def test_product_name_with_serial_and_iface(self):
+        bms = self._bms(serial="BB02")
+        assert bms.product_name() == "SerialBattery BB02 @ ttyUSB0 (JKBMS PB Model)"
+
+    def test_product_name_falls_back_to_address_hex(self):
+        bms = self._bms(addr=0x05, serial="")
+        assert bms.product_name() == "SerialBattery 0x05 @ ttyUSB0 (JKBMS PB Model)"
+
+    def test_product_name_uses_port_basename(self):
+        bms = self._bms(port="/dev/ttyUSB1", serial="BB02")
+        assert "ttyUSB1" in bms.product_name()
+        assert "/dev/" not in bms.product_name()
+
+    def test_product_name_starts_with_serialbattery_prefix(self):
+        # Required for dbus-aggregate-batteries detection.
+        bms = self._bms(serial="BB02")
+        assert bms.product_name().startswith("SerialBattery ")
+
+    def test_custom_name_empty(self):
+        # GUI falls back to ProductName; user-typed names are persisted
+        # by dbushelper.callback_custom_name and override this default.
+        bms = self._bms(serial="BB02")
+        assert bms.custom_name() == ""


### PR DESCRIPTION
In large installations with a lot of batteries, it is very confusing to the user, if all batteries have exactly the same product name. For JKBMS, we can improve this very easily, by including the "device name", which can be set by the JKBMS app. Addtionally, this PR adds the interface used for communication.

Additionally, I fixed a small bug, that prevented the field "Name" to be (re-)set to an empty string, e.g. to clear a previously set non-empty value.

<img width="1204" height="799" alt="image" src="https://github.com/user-attachments/assets/5b3554b9-c3ac-4207-8f33-4e2dc79e7199" />

<img width="1204" height="799" alt="image" src="https://github.com/user-attachments/assets/755f6241-9b88-43e2-8cf6-b80e4788fcd5" />


Remark 1: I tried to use the "Name" before, but this caused a lot of confusion as it is stored per instance permanently on the Cerbo. When instances are shuffeled, the names begin to move around, which is not helpful at all.

Remark 2: the string "SerialBattery" must be kept to ensure compatibility with dbus-aggregate-batteries