### PR TITLE
Skip missing temperature adjustment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * Changed: GUIv2 - With Venus OS `v3.80~21` GUIv2 plugins are used instead of fully customized GUI by @mr-manuel
 * Changed: GUIv2: Add cell diff to mean and improve calculations to reduce CPU load. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/360 by @mr-manuel
 * Changed: History values: Fix calculation of some values by @mr-manuel
+* Changed: Temperature compensation - Preserve missing temperature sensor values instead of crashing when applying adjustment settings. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/457 by @akmhatey-ai
 * Changed: HLPDATA BMS - Fixed wrong charge/discharge fet assignment @mr-manuel
 * Changed: HLPDATA BMS - Fixed wrong charge/discharge fet assignment @mr-manuel
 * Changed: Improved BMS Cable Alarm Logic. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/309 by @mr-manuel

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -30,6 +30,12 @@ VICTRON_SETTINGS_IFACE_NAME = "com.victronenergy.Settings"
 _SENTINEL = object()
 
 
+def _adjust_temperature(value, adjustment):
+    if value is None:
+        return None
+    return (value * adjustment[1]) + adjustment[0]
+
+
 class _CachedDbusProxy:
     """Thin proxy around VeDbusService that suppresses redundant D-Bus writes.
 
@@ -976,11 +982,11 @@ class DbusHelper:
                 self.battery.set_calculated_data()
 
                 # Adjust temperature readings
-                self.battery.temperature_1 = (self.battery.temperature_1 * utils.TEMPERATURE_1_ADJUST[1]) + utils.TEMPERATURE_1_ADJUST[0]
-                self.battery.temperature_2 = (self.battery.temperature_2 * utils.TEMPERATURE_2_ADJUST[1]) + utils.TEMPERATURE_2_ADJUST[0]
-                self.battery.temperature_3 = (self.battery.temperature_3 * utils.TEMPERATURE_3_ADJUST[1]) + utils.TEMPERATURE_3_ADJUST[0]
-                self.battery.temperature_4 = (self.battery.temperature_4 * utils.TEMPERATURE_4_ADJUST[1]) + utils.TEMPERATURE_4_ADJUST[0]
-                self.battery.temperature_mos = (self.battery.temperature_mos * utils.TEMPERATURE_MOS_ADJUST[1]) + utils.TEMPERATURE_MOS_ADJUST[0]
+                self.battery.temperature_1 = _adjust_temperature(self.battery.temperature_1, utils.TEMPERATURE_1_ADJUST)
+                self.battery.temperature_2 = _adjust_temperature(self.battery.temperature_2, utils.TEMPERATURE_2_ADJUST)
+                self.battery.temperature_3 = _adjust_temperature(self.battery.temperature_3, utils.TEMPERATURE_3_ADJUST)
+                self.battery.temperature_4 = _adjust_temperature(self.battery.temperature_4, utils.TEMPERATURE_4_ADJUST)
+                self.battery.temperature_mos = _adjust_temperature(self.battery.temperature_mos, utils.TEMPERATURE_MOS_ADJUST)
 
                 # This is to manage CVCL
                 self.battery.manage_charge_voltage()

--- a/tests/test_dbushelper_temperature.py
+++ b/tests/test_dbushelper_temperature.py
@@ -1,0 +1,22 @@
+"""Regression tests for D-Bus temperature adjustment helpers."""
+
+import pytest
+
+from dbushelper import _adjust_temperature
+
+
+def test_adjust_temperature_preserves_missing_sensor_value():
+    assert _adjust_temperature(None, [0.0, 1.0]) is None
+
+
+@pytest.mark.parametrize(
+    "value,adjustment,expected",
+    [
+        (25.0, [0.0, 1.0], 25.0),
+        (25.0, [1.5, 1.0], 26.5),
+        (25.0, [0.0, 1.1], 27.5),
+        (-5.0, [-1.0, 0.5], -3.5),
+    ],
+)
+def test_adjust_temperature_applies_offset_and_multiplier(value, adjustment, expected):
+    assert _adjust_temperature(value, adjustment) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- Preserve missing temperature sensor values when applying configured temperature adjustments.
- This prevents startup from crashing when a BMS reports sensors 1/2 but leaves sensor 3/4 or MOS temperature as `None`.
- Added a small regression test for the adjustment helper and a changelog entry.

Fixes #457.

## Validation
- `uv run --with pytest --with pyserial pytest tests/test_dbushelper_temperature.py -q` -> `5 passed`
- `uv run --with pytest --with pyserial pytest tests/test_dbushelper_temperature.py tests/test_cached_dbus_proxy.py tests/test_get_bus.py -q` -> `36 passed`
- `uv run --with pytest --with pyserial pytest --ignore=tests/bms -q` -> `54 passed`
- `uv run --with black black --check dbus-serialbattery/dbushelper.py tests/test_dbushelper_temperature.py` -> passed
- `uv run --with flake8 flake8 dbus-serialbattery/dbushelper.py tests/test_dbushelper_temperature.py` -> passed
- `git diff --cached --check` -> passed
- `gitleaks protect --staged --redact --verbose` -> no leaks found

I also tried `uv run --with pytest --with pyserial pytest -q`; on Windows it stops during collection because `tests/bms/test_lltjbd_up16s.py` imports the Unix-only `termios` module.