### PR TITLE
use dedicated heating values with most recent firmware version with 15A hardware

### DIFF
--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -273,9 +273,9 @@ class Jkbms_pb(Battery):
             sw_version = status_data[30:37].decode("utf-8").split("\x00", 1)[0]  # 8 chars
             bms_version = hw_version + " / " + sw_version
 
-            # if we have an older hardware older as 19A (starting with 19A the FW supports the heating temperature setting)
-            # we use the old behavior by using the Bat Charge Under Temperature and Reset value
-            if hw_version > "15A":
+            # hardware newer than 15A and 15A with fw >= 15.41 support the dedicated heating temperature setting
+            # older combinations fall back to the Bat Charge Under Temperature and Reset value
+            if hw_version > "15A" or (hw_version == "15A" and sw_version >= "15.41"):
                 self.heater_temperature_start = TMPStartHeating
                 self.heater_temperature_stop = TMPStopHeating
             else:

--- a/dbus-serialbattery/bms/jkbms_pb.py
+++ b/dbus-serialbattery/bms/jkbms_pb.py
@@ -275,7 +275,12 @@ class Jkbms_pb(Battery):
 
             # hardware newer than 15A and 15A with fw >= 15.41 support the dedicated heating temperature setting
             # older combinations fall back to the Bat Charge Under Temperature and Reset value
-            if hw_version > "15A" or (hw_version == "15A" and sw_version >= "15.41"):
+            try:
+                sw_version_tuple = tuple(int(part) for part in sw_version.split("."))
+            except ValueError:
+                sw_version_tuple = ()
+
+            if hw_version > "15A" or (hw_version == "15A" and sw_version_tuple >= (15, 41)):
                 self.heater_temperature_start = TMPStartHeating
                 self.heater_temperature_stop = TMPStopHeating
             else:


### PR DESCRIPTION
The most recent and probably final firmware version v15.41 for the hardware version 15A implemented support for the dedicated heating start and stop values, so use them if available.