### PR TITLE
Refresh LastSeen daily so that long uptimes don't delete sibling batteries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Changed: Daly BMS & Daly CAN BMS: Fix high charge/discharge current alarm. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/378 by @mr-manuel
 * Changed: Daren 485 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
 * Changed: dbushelper.py - Ensure loading of newest battery data if more than one duplicate exists by @lex2k0
+* Changed: dbushelper.py - Refresh the `LastSeen` setting daily while the driver is running. Previously it was written only at startup, so after more than 30 days of continuous uptime a restart deleted the settings (device instance, custom name, history) of all other batteries sharing the port by @dmitrych5
 * Changed: dbushelper.py - Reworked save settings methods by @lex2k0
 * Changed: Decoupled SOC Reset after x days from the need that the battery has to switch to bulk charge, thus after every x days are passed by there will be a bulk charge / top balancing by @lex2k0
 * Changed: Disabled BMS SOC alerts if `SOC_CALCULATION` is enabled. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/377 by @mr-manuel

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -158,6 +158,10 @@ class DbusHelper:
         """
         Last time the history values were calculated.
         """
+        self.last_seen_saved_last_time: int = 0
+        """
+        Last time the LastSeen dbus setting was refreshed.
+        """
         self.telemetry_upload_error_count: int = 0
         self.telemetry_upload_interval: int = 60 * 60 * 3  # 3 hours
         self.telemetry_upload_last: int = 0
@@ -1443,6 +1447,18 @@ class DbusHelper:
         if int(time()) - self.settings_saved_last_time >= 15:
             self.save_current_battery_state()
             self.settings_saved_last_time = int(time())
+
+        # refresh LastSeen daily: setup_instance() removes entries not seen for over 30 days,
+        # which orphans the other batteries on this port once driver uptime exceeds that
+        if int(time()) - self.last_seen_saved_last_time >= 60 * 60 * 24:
+            self.set_settings(
+                get_bus(VICTRON_SETTINGS_DBUS_NAME),
+                VICTRON_SETTINGS_DBUS_NAME,
+                self.path_battery,
+                "LastSeen",
+                int(time()),
+            )
+            self.last_seen_saved_last_time = int(time())
 
         if self.battery.soc is not None:
             logger.debug("logged to dbus [%s]" % str(round(self.battery.soc, 2)))


### PR DESCRIPTION
setup_instance() deletes /Settings/Devices entries whose LastSeen is older than 30 days and whose UniqueIdentifier doesn't match the battery being set up, but LastSeen is only ever written once, when a battery is set up. When the driver runs continuously for more than 30 days on a port with multiple batteries, every entry goes stale; on the next restart, the first battery to initialize deletes the other batteries' entries before they get their turn to reconnect. They then come up as new devices with new VRM instances, default names, and empty history.

The fix is to refresh LastSeen once a day from publish_battery().
The refresh is throttled by an in-memory timestamp rather than by reading LastSeen back from dbus: publish_battery() runs every second, and a dbus read per cycle just to skip a once-a-day write isn't worth it. This follows the same pattern as history_calculated_last_time and settings_saved_last_time.