### PR TITLE
Add config option to select the Bluetooth LE connection backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte
 * Added: dbus caching to reduce writes and therefore CPU consumption with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/397 by @cgoudie

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -141,6 +141,11 @@ BLUETOOTH_USE_POLLING = True
 ; Try to reset the BLE stack if the connection is lost or a crash is detected.
 BLUETOOTH_FORCE_RESET_BLE_STACK = False
 
+; Backend used to establish Bluetooth LE connections.
+; Available backends:
+;     BleakBackend: Connect directly with bleak
+BLUETOOTH_CONNECTION_BACKEND = BleakBackend
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -261,6 +261,7 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 # --------- Bluetooth BMS ---------
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
+BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -4,7 +4,68 @@ import subprocess
 import sys
 from bleak import BleakClient
 from time import sleep
-from utils import logger, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+
+
+class BleConnectionBackend:
+    """
+    Interface for establishing and releasing BLE connections.
+
+    Separates how a connection is established/torn down (the backend) from how
+    Syncron_Ble supervises it and exchanges data with the BMS drivers. This allows
+    alternative connection strategies to be plugged in without touching the drivers.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        """
+        Create the BleakClient for the given address, or None if the backend
+        creates its own client during establish().
+        """
+        raise NotImplementedError
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        """
+        Connect and start notifications. Returns the connected client
+        (may differ from the one passed in). Raises on failure.
+        """
+        raise NotImplementedError
+
+    async def release(self, client):
+        """Disconnect the client."""
+        raise NotImplementedError
+
+
+class BleakBackend(BleConnectionBackend):
+    """
+    Default backend: connects directly with bleak, matching the historical
+    behavior of this driver.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        return BleakClient(address, disconnected_callback=disconnected_callback)
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        logger.info("initiating BLE connection to: " + address)
+        await client.connect()
+        logger.info("connected to bluetooh device" + address)
+        await client.start_notify(notify_char, notify_callback)
+        return client
+
+    async def release(self, client):
+        await client.disconnect()
+
+
+# Available connection backends, selected by class name via BLUETOOTH_CONNECTION_BACKEND
+supported_ble_backends = [BleakBackend]
+
+
+def get_ble_backend():
+    """Return the connection backend selected by BLUETOOTH_CONNECTION_BACKEND."""
+    for backend in supported_ble_backends:
+        if backend.__name__ == BLUETOOTH_CONNECTION_BACKEND:
+            return backend()
+    logger.warning(f"Unknown BLUETOOTH_CONNECTION_BACKEND '{BLUETOOTH_CONNECTION_BACKEND}', using 'BleakBackend'")
+    return BleakBackend()
 
 
 # Class that enables synchronous writing and reading to a bluetooh device
@@ -34,6 +95,7 @@ class Syncron_Ble:
         self.write_characteristic = write_characteristic
         self.read_characteristic = read_characteristic
         self.address = address
+        self.backend = get_ble_backend()
 
         # Start a new thread that will run bleak the async bluetooth LE library
         self.main_thread = threading.current_thread()
@@ -65,21 +127,19 @@ class Syncron_Ble:
         logger.error(f"bluetooh device with address: {self.address} disconnected")
 
     async def connect_to_bms(self, address):
-        self.client = BleakClient(address, disconnected_callback=self.client_disconnected)
+        self.client = self.backend.create_client(address, self.client_disconnected)
         try:
-            logger.info("initiating BLE connection to: " + address)
-            await self.client.connect()
-            logger.info("connected to bluetooh device" + address)
-            await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
+            self.client = await self.backend.establish(self.client, address, self.read_characteristic, self.notify_read_callback)
 
         except Exception as e:
             logger.error("Failed when trying to connect", e)
             return False
         finally:
             self.ble_connection_ready.set()
-            while self.client.is_connected and self.main_thread.is_alive():
-                await asyncio.sleep(0.1)
-            await self.client.disconnect()
+            if self.client:
+                while self.client.is_connected and self.main_thread.is_alive():
+                    await asyncio.sleep(0.1)
+                await self.backend.release(self.client)
 
     # saves response and tells the command sender that the response has arived
     def notify_read_callback(self, sender, data: bytearray):


### PR DESCRIPTION
### Describe the changes

This is a pure refactor with no behavior change. It extracts the connection establish/teardown logic from `Syncron_Ble` into a small `BleConnectionBackend` interface, with one implementation: `BleakBackend`, which is the existing direct-bleak connection path extracted verbatim (same call order, same log messages, same error handling).

A new config option selects the backend, following the same class-name convention as `BLUETOOTH_BMS`:

```ini
; Backend used to establish Bluetooth LE connections.
; Available backends:
;     BleakBackend: Connect directly with bleak
BLUETOOTH_CONNECTION_BACKEND = BleakBackend
```

Unknown values log a warning and fall back to `BleakBackend`. The BMS drivers (`Jkbms_Ble`, `Kilovault_Ble`, `LiTime_Ble`, `LltJbd_Ble`, `Xdzn_Ble`) are untouched — the `Syncron_Ble` API they use is unchanged.

### Motivation

Bluetooth connection stability is a recurring topic (e.g. #446, #449). This seam makes it possible to offer alternative, opt-in connection strategies — a follow-up PR will add an optional backend based on [bleak-connection-manager](https://github.com/TechBlueprints/bleak-connection-manager) (connection retry/escalation, watchdog) behind this config option, keeping the default install and default behavior exactly as today.

### Status

Draft for now — I'll update the draft once I've run it on my Cerbo.

### Checklist

* Ran flake8 and black (max-line-length 160) — clean
* CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
