### PR TITLE
Add BLUETOOTH_ADAPTERS to restrict BLE connections to specific adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte
 * Added: dbus caching to reduce writes and therefore CPU consumption with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/397 by @cgoudie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_ADAPTERS` config option to restrict Bluetooth LE BMS connections to specific adapters (hciX), rotating to the next listed adapter after a failed attempt. Helps on GX devices with multiple adapters where the default adapter is contended or unstable by @cgoudie
 * Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -146,6 +146,18 @@ BLUETOOTH_FORCE_RESET_BLE_STACK = False
 ;     BleakBackend: Connect directly with bleak
 BLUETOOTH_CONNECTION_BACKEND = BleakBackend
 
+; Bluetooth adapters (hciX) to use for BLE BMS connections.
+; Connections are made only via the listed adapters, in order, rotating to
+; the next entry after a failed connection attempt.
+; Empty = use the system default adapter.
+; Useful on GX devices with multiple Bluetooth adapters where the default
+; adapter is heavily used by other services: scan contention can make
+; connections fail with org.bluez.Error.InProgress, and a misbehaving
+; controller drops every BLE connection on that adapter at once.
+; Example:
+;     BLUETOOTH_ADAPTERS = hci1, hci2
+BLUETOOTH_ADAPTERS =
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -141,6 +141,11 @@ BLUETOOTH_USE_POLLING = True
 ; Try to reset the BLE stack if the connection is lost or a crash is detected.
 BLUETOOTH_FORCE_RESET_BLE_STACK = False
 
+; Backend used to establish Bluetooth LE connections.
+; Available backends:
+;     BleakBackend: Connect directly with bleak
+BLUETOOTH_CONNECTION_BACKEND = BleakBackend
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -261,6 +261,7 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 # --------- Bluetooth BMS ---------
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
+BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -262,6 +262,9 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
 BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
+# Bluetooth adapters (hciX) to use for BLE BMS connections, tried in order.
+# Empty list = use the system default adapter.
+BLUETOOTH_ADAPTERS: List[str] = get_list_from_config("DEFAULT", "BLUETOOTH_ADAPTERS", str)
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -4,7 +4,68 @@ import subprocess
 import sys
 from bleak import BleakClient
 from time import sleep
-from utils import logger, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+
+
+class BleConnectionBackend:
+    """
+    Interface for establishing and releasing BLE connections.
+
+    Separates how a connection is established/torn down (the backend) from how
+    Syncron_Ble supervises it and exchanges data with the BMS drivers. This allows
+    alternative connection strategies to be plugged in without touching the drivers.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        """
+        Create the BleakClient for the given address, or None if the backend
+        creates its own client during establish().
+        """
+        raise NotImplementedError
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        """
+        Connect and start notifications. Returns the connected client
+        (may differ from the one passed in). Raises on failure.
+        """
+        raise NotImplementedError
+
+    async def release(self, client):
+        """Disconnect the client."""
+        raise NotImplementedError
+
+
+class BleakBackend(BleConnectionBackend):
+    """
+    Default backend: connects directly with bleak, matching the historical
+    behavior of this driver.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        return BleakClient(address, disconnected_callback=disconnected_callback)
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        logger.info("initiating BLE connection to: " + address)
+        await client.connect()
+        logger.info("connected to bluetooh device" + address)
+        await client.start_notify(notify_char, notify_callback)
+        return client
+
+    async def release(self, client):
+        await client.disconnect()
+
+
+# Available connection backends, selected by class name via BLUETOOTH_CONNECTION_BACKEND
+supported_ble_backends = [BleakBackend]
+
+
+def get_ble_backend():
+    """Return the connection backend selected by BLUETOOTH_CONNECTION_BACKEND."""
+    for backend in supported_ble_backends:
+        if backend.__name__ == BLUETOOTH_CONNECTION_BACKEND:
+            return backend()
+    logger.warning(f"Unknown BLUETOOTH_CONNECTION_BACKEND '{BLUETOOTH_CONNECTION_BACKEND}', using 'BleakBackend'")
+    return BleakBackend()
 
 
 # Class that enables synchronous writing and reading to a bluetooh device
@@ -34,6 +95,7 @@ class Syncron_Ble:
         self.write_characteristic = write_characteristic
         self.read_characteristic = read_characteristic
         self.address = address
+        self.backend = get_ble_backend()
 
         # Start a new thread that will run bleak the async bluetooth LE library
         self.main_thread = threading.current_thread()
@@ -65,21 +127,19 @@ class Syncron_Ble:
         logger.error(f"bluetooh device with address: {self.address} disconnected")
 
     async def connect_to_bms(self, address):
-        self.client = BleakClient(address, disconnected_callback=self.client_disconnected)
+        self.client = self.backend.create_client(address, self.client_disconnected)
         try:
-            logger.info("initiating BLE connection to: " + address)
-            await self.client.connect()
-            logger.info("connected to bluetooh device" + address)
-            await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
+            self.client = await self.backend.establish(self.client, address, self.read_characteristic, self.notify_read_callback)
 
         except Exception as e:
             logger.error("Failed when trying to connect", e)
             return False
         finally:
             self.ble_connection_ready.set()
-            while self.client.is_connected and self.main_thread.is_alive():
-                await asyncio.sleep(0.1)
-            await self.client.disconnect()
+            if self.client:
+                while self.client.is_connected and self.main_thread.is_alive():
+                    await asyncio.sleep(0.1)
+                await self.backend.release(self.client)
 
     # saves response and tells the command sender that the response has arived
     def notify_read_callback(self, sender, data: bytearray):

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from bleak import BleakClient
 from time import sleep
-from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_ADAPTERS, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
 
 
 class BleConnectionBackend:
@@ -39,16 +39,34 @@ class BleakBackend(BleConnectionBackend):
     """
     Default backend: connects directly with bleak, matching the historical
     behavior of this driver.
+
+    If BLUETOOTH_ADAPTERS is set, connections are made only via the listed
+    adapters, rotating to the next entry after a failed attempt. An empty
+    list uses the system default adapter.
     """
 
+    def __init__(self):
+        self.adapter_index = 0
+        self.current_adapter = None
+
     def create_client(self, address, disconnected_callback):
-        return BleakClient(address, disconnected_callback=disconnected_callback)
+        kwargs = {}
+        if BLUETOOTH_ADAPTERS:
+            self.current_adapter = BLUETOOTH_ADAPTERS[self.adapter_index % len(BLUETOOTH_ADAPTERS)]
+            kwargs["adapter"] = self.current_adapter
+        return BleakClient(address, disconnected_callback=disconnected_callback, **kwargs)
 
     async def establish(self, client, address, notify_char, notify_callback):
-        logger.info("initiating BLE connection to: " + address)
-        await client.connect()
-        logger.info("connected to bluetooh device" + address)
-        await client.start_notify(notify_char, notify_callback)
+        logger.info("initiating BLE connection to: " + address + (f" (adapter {self.current_adapter})" if self.current_adapter else ""))
+        try:
+            await client.connect()
+            logger.info("connected to bluetooh device" + address)
+            await client.start_notify(notify_char, notify_callback)
+        except Exception:
+            # rotate to the next configured adapter for the next attempt
+            if BLUETOOTH_ADAPTERS:
+                self.adapter_index += 1
+            raise
         return client
 
     async def release(self, client):


### PR DESCRIPTION
> **Stacked on #494** (BLE connection backend). The first commit here is #494's; please review only the last commit. I'll rebase this branch once #494 lands so it contains only the feature commit.

## What

Adds a `BLUETOOTH_ADAPTERS` config option that restricts Bluetooth LE BMS connections to a specific list of adapters (`hciX`), tried in order, rotating to the next entry after a failed connection attempt. An empty list (the default) keeps today's behavior of using the system default adapter.

Implemented in `BleakBackend` from #494, so it applies to every BMS that connects through `Syncron_Ble`, with no per-driver changes.

```ini
; connect only via these adapters, never the built-in one
BLUETOOTH_ADAPTERS = hci1, hci2
```

## Why

On GX devices with multiple Bluetooth adapters (a common setup precisely because BLE is unstable), bleak always connects via the system default adapter. Two real failure modes observed on a Cerbo GX (Venus OS v3.73, four adapters, several BLE services sharing them):

1. **Scan contention:** bleak's address-based connect first runs a discovery scan. When another service holds the default adapter's scan slot, `StartDiscovery` fails with `org.bluez.Error.InProgress` — on a busy adapter this can persist for minutes, so the driver's reconnect loop never wins the race.
2. **Controller instability takes down every link at once:** kernel logs showed vendor-opcode errors on the built-in adapter (`Bluetooth: hci0: unexpected event for opcode 0xfc19`) coinciding, to the second, with simultaneous disconnects of every BLE BMS on that adapter.

Pinning the BMS connections to dedicated (or idle) adapters avoids both: the listed adapters aren't scan-contended, and a glitch on the busy default adapter no longer touches the BMS links.

## Scope

- `utils.py`: parse `BLUETOOTH_ADAPTERS` (list of strings, default empty)
- `utils_ble.py`: `BleakBackend` passes `adapter=` to `BleakClient` and rotates through the list on failed attempts
- `config.default.ini`, `CHANGELOG.md`: documentation

No behavior change when the option is unset.

## Testing

The mechanism (passing `adapter=` to `BleakClient`, rotating through a configured list on failed attempts) is running on a Cerbo GX (Venus OS v3.73) against two production BLE batteries via an equivalent implementation in the HumsiENK driver branch (#495): with a `hci2, hci4, hci3` list, both instances connect only via the listed adapters, each attempt logs the adapter used, and rotation advances on failure until an attempt succeeds. This PR ports that validated logic into `BleakBackend` so all `Syncron_Ble`-based BMS benefit; the `BleakBackend` code path itself is lint-clean and behavior-identical, and with the option unset (the default) connection behavior is unchanged. I'll report back once this exact branch has soak time on the Cerbo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
