### PR TITLE
Add BCMBackend: opt-in managed BLE connection backend (bleak-connection-manager)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte
 * Added: dbus caching to reduce writes and therefore CPU consumption with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/397 by @cgoudie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_ADAPTERS` config option to restrict Bluetooth LE BMS connections to specific adapters (hciX), rotating to the next listed adapter after a failed attempt. Helps on GX devices with multiple adapters where the default adapter is contended or unstable by @cgoudie
 * Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -144,6 +144,9 @@ BLUETOOTH_FORCE_RESET_BLE_STACK = False
 ; Backend used to establish Bluetooth LE connections.
 ; Available backends:
 ;     BleakBackend: Connect directly with bleak
+;     BCMBackend: Managed connections via bleak-connection-manager, for hosts where
+;         multiple BLE services contend for the Bluetooth adapters (cache-first device
+;         resolution without discovery scans, connect retries with adapter escalation)
 BLUETOOTH_CONNECTION_BACKEND = BleakBackend
 
 ; Bluetooth adapters (hciX) to use for BLE BMS connections.

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -146,6 +146,18 @@ BLUETOOTH_FORCE_RESET_BLE_STACK = False
 ;     BleakBackend: Connect directly with bleak
 BLUETOOTH_CONNECTION_BACKEND = BleakBackend
 
+; Bluetooth adapters (hciX) to use for BLE BMS connections.
+; Connections are made only via the listed adapters, in order, rotating to
+; the next entry after a failed connection attempt.
+; Empty = use the system default adapter.
+; Useful on GX devices with multiple Bluetooth adapters where the default
+; adapter is heavily used by other services: scan contention can make
+; connections fail with org.bluez.Error.InProgress, and a misbehaving
+; controller drops every BLE connection on that adapter at once.
+; Example:
+;     BLUETOOTH_ADAPTERS = hci1, hci2
+BLUETOOTH_ADAPTERS =
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -141,6 +141,11 @@ BLUETOOTH_USE_POLLING = True
 ; Try to reset the BLE stack if the connection is lost or a crash is detected.
 BLUETOOTH_FORCE_RESET_BLE_STACK = False
 
+; Backend used to establish Bluetooth LE connections.
+; Available backends:
+;     BleakBackend: Connect directly with bleak
+BLUETOOTH_CONNECTION_BACKEND = BleakBackend
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/ext/bleak_connection_manager/__init__.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/__init__.py
@@ -1,0 +1,124 @@
+"""bleak-connection-manager: Robust BLE connection lifecycle manager.
+
+Wraps bleak-retry-connector with production-hardened workarounds for
+real-world BlueZ failure modes.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+from .adapters import discover_adapters, make_device_for_adapter, pick_adapter
+from .bluez import (
+    address_to_bluez_path,
+    disconnect_device,
+    is_inactive_connection,
+    remove_device,
+    verified_disconnect,
+)
+from .connection import establish_connection
+from .const import (
+    DEFAULT_MAX_ATTEMPTS,
+    DISCONNECT_TIMEOUT,
+    IS_LINUX,
+    THREAD_SAFETY_TIMEOUT,
+    LockConfig,
+    ScanLockConfig,
+)
+from .diagnostics import StuckState, clear_stuck_state, diagnose_stuck_state
+from .hci import (
+    HCI_DISCONNECT_REASONS,
+    HciConnection,
+    cancel_le_connect,
+    disconnect_by_address,
+    disconnect_handle,
+    disconnect_reason_str,
+    find_connection_by_address,
+    get_connections,
+    hci_available,
+)
+from .lock import acquire_lock, acquire_slot, release_lock, release_slot
+from .scan_lock import ScanLock, acquire_scan_lock, release_scan_lock
+from .scanner import discover as managed_discover
+from .scanner import find_device as managed_find_device
+from .recovery import (
+    PROFILE_BATTERY,
+    PROFILE_ON_DEMAND,
+    PROFILE_SENSOR,
+    EscalationAction,
+    EscalationConfig,
+    EscalationPolicy,
+    invalidate_dbus_state,
+    is_bluetoothd_alive,
+    reset_adapter,
+)
+from .dbus_bus import is_service_unknown_error, mark_bluez_gone, wait_for_bluez
+from .validators import validate_char_exists, validate_gatt_services, validate_read_char
+from .watchdog import ConnectionWatchdog
+
+__all__ = [
+    # Core connection function
+    "establish_connection",
+    # Watchdog
+    "ConnectionWatchdog",
+    # Lock / slot-based concurrency control (connections)
+    "LockConfig",
+    "acquire_slot",
+    "release_slot",
+    "acquire_lock",  # backwards-compatible alias for acquire_slot
+    "release_lock",  # backwards-compatible alias for release_slot
+    # Lock / scan concurrency control
+    "ScanLockConfig",
+    "ScanLock",
+    "acquire_scan_lock",
+    "release_scan_lock",
+    # Adapters
+    "discover_adapters",
+    "make_device_for_adapter",
+    "pick_adapter",
+    # BlueZ utilities
+    "address_to_bluez_path",
+    "disconnect_device",
+    "is_inactive_connection",
+    "remove_device",
+    "verified_disconnect",
+    # Diagnostics
+    "StuckState",
+    "clear_stuck_state",
+    "diagnose_stuck_state",
+    # HCI layer (connection state via hcitool)
+    "HciConnection",
+    "HCI_DISCONNECT_REASONS",
+    "disconnect_reason_str",
+    "hci_available",
+    "get_connections",
+    "find_connection_by_address",
+    "disconnect_handle",
+    "disconnect_by_address",
+    "cancel_le_connect",
+    # Recovery / escalation
+    "is_bluetoothd_alive",
+    "is_service_unknown_error",
+    "mark_bluez_gone",
+    "wait_for_bluez",
+    "EscalationAction",
+    "EscalationConfig",
+    "EscalationPolicy",
+    "PROFILE_BATTERY",
+    "PROFILE_ON_DEMAND",
+    "PROFILE_SENSOR",
+    "invalidate_dbus_state",
+    "reset_adapter",
+    # Validators
+    "validate_char_exists",
+    "validate_gatt_services",
+    "validate_read_char",
+    # Managed scanning (lock + rotation + retry)
+    "managed_find_device",
+    "managed_discover",
+    # Constants
+    "DEFAULT_MAX_ATTEMPTS",
+    "DISCONNECT_TIMEOUT",
+    "IS_LINUX",
+    "THREAD_SAFETY_TIMEOUT",
+]

--- a/dbus-serialbattery/ext/bleak_connection_manager/adapters.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/adapters.py
@@ -1,0 +1,237 @@
+"""Adapter enumeration, rotation, and scoring for multi-adapter BLE systems.
+
+Wraps ``bluetooth-adapters`` for enumeration and adds both round-robin
+rotation and score-based selection logic for distributing connection
+attempts across adapters.
+
+When multiple USB BLE adapters are available, rotating between them
+avoids saturating a single adapter and works around per-adapter
+connection limits in BlueZ.
+
+Score-based selection (inspired by habluetooth's
+``_score_connection_paths``) improves on blind round-robin by
+considering free connection slots, recent failure history, and
+in-progress connections when choosing which adapter to try next.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from bleak.backends.device import BLEDevice
+
+from .const import IS_LINUX
+
+if TYPE_CHECKING:
+    from .const import LockConfig
+    from .recovery import EscalationPolicy
+
+_LOGGER = logging.getLogger(__name__)
+
+# ── Scoring constants ──────────────────────────────────────────────
+#
+# Inspired by habluetooth's _score_connection_paths().
+# A higher score means a better adapter to try.
+
+_BASE_SCORE = 100.0
+_PENALTY_PER_FAILURE = 15.0
+_PENALTY_PER_IN_PROGRESS = 20.0
+_PENALTY_NO_FREE_SLOTS = 200.0  # effectively disqualifies
+_PENALTY_LAST_SLOT = 10.0
+
+
+def discover_adapters() -> list[str]:
+    """Discover available BLE adapters on the system.
+
+    Uses ``bluetooth-adapters`` when available, falls back to
+    ``/sys/class/bluetooth/`` enumeration.
+
+    Returns a sorted list of adapter names (e.g. ``["hci0", "hci1"]``).
+    Returns ``["hci0"]`` as a safe default if no adapters are found.
+    """
+    if not IS_LINUX:
+        return ["hci0"]
+
+    # Try bluetooth-adapters first (more reliable, handles USB adapters)
+    try:
+        from bluetooth_adapters import get_adapters_from_hci
+
+        adapters_from_hci = get_adapters_from_hci()
+        if adapters_from_hci:
+            names = sorted(a["name"] for a in adapters_from_hci.values())
+            if names:
+                _LOGGER.debug("Discovered adapters via bluetooth-adapters: %s", names)
+                return names
+    except Exception:
+        _LOGGER.debug(
+            "bluetooth-adapters enumeration failed, trying /sys",
+            exc_info=True,
+        )
+
+    # Fallback: /sys/class/bluetooth/
+    try:
+        import pathlib
+
+        bt_path = pathlib.Path("/sys/class/bluetooth")
+        if bt_path.exists():
+            adapters = sorted(
+                d.name for d in bt_path.iterdir() if d.name.startswith("hci")
+            )
+            if adapters:
+                _LOGGER.debug("Discovered adapters via /sys: %s", adapters)
+                return adapters
+    except Exception:
+        _LOGGER.debug("Failed to enumerate /sys/class/bluetooth", exc_info=True)
+
+    return ["hci0"]
+
+
+def pick_adapter(
+    adapters: list[str],
+    attempt: int,
+) -> str:
+    """Pick an adapter for the current attempt using round-robin.
+
+    Parameters
+    ----------
+    adapters:
+        List of available adapter names (e.g. ``["hci0", "hci1"]``).
+    attempt:
+        The current attempt number (1-based).
+
+    Returns the adapter to use for this attempt.
+    """
+    if not adapters:
+        return "hci0"
+    idx = (attempt - 1) % len(adapters)
+    return adapters[idx]
+
+
+def score_adapter(
+    adapter: str,
+    *,
+    escalation_policy: EscalationPolicy | None = None,
+    lock_config: LockConfig | None = None,
+    in_progress: dict[str, int] | None = None,
+) -> float:
+    """Score an adapter for connection suitability (higher = better).
+
+    Factors considered (inspired by habluetooth's scoring):
+
+    - **Free connection slots**: No free slots → heavy penalty.
+      Last slot free → small penalty.
+    - **Failure history**: Each consecutive failure on this adapter
+      incurs a penalty.
+    - **In-progress connections**: Each ongoing connection attempt
+      on this adapter incurs a penalty (avoids piling onto a busy
+      adapter).
+
+    Parameters
+    ----------
+    adapter:
+        The adapter name (e.g. ``"hci0"``).
+    escalation_policy:
+        If provided, failure count is read from here.
+    lock_config:
+        If provided and enabled, free slot count is probed.
+    in_progress:
+        Dict mapping adapter → number of connection attempts
+        currently in flight.  If ``None``, no in-progress penalty.
+    """
+    score = _BASE_SCORE
+
+    # --- Failure penalty ---
+    if escalation_policy is not None:
+        failures = escalation_policy.failure_count(adapter)
+        score -= _PENALTY_PER_FAILURE * failures
+
+    # --- In-progress penalty ---
+    if in_progress is not None:
+        count = in_progress.get(adapter, 0)
+        score -= _PENALTY_PER_IN_PROGRESS * count
+
+    # --- Slot availability penalty ---
+    if lock_config is not None and lock_config.enabled:
+        from .lock import probe_free_slots
+
+        free = probe_free_slots(lock_config, adapter)
+        if free == 0:
+            score -= _PENALTY_NO_FREE_SLOTS
+        elif free == 1:
+            score -= _PENALTY_LAST_SLOT
+
+    return score
+
+
+def select_best_adapter(
+    adapters: list[str],
+    *,
+    escalation_policy: EscalationPolicy | None = None,
+    lock_config: LockConfig | None = None,
+    in_progress: dict[str, int] | None = None,
+) -> str:
+    """Select the best adapter from a list using score-based ranking.
+
+    Falls back to the first adapter if all scores are equal.
+
+    Parameters are the same as :func:`score_adapter`.
+    """
+    if not adapters:
+        return "hci0"
+    if len(adapters) == 1:
+        return adapters[0]
+
+    best_adapter = adapters[0]
+    best_score = float("-inf")
+
+    for adapter in adapters:
+        s = score_adapter(
+            adapter,
+            escalation_policy=escalation_policy,
+            lock_config=lock_config,
+            in_progress=in_progress,
+        )
+        _LOGGER.debug("Adapter %s score: %.1f", adapter, s)
+        if s > best_score:
+            best_score = s
+            best_adapter = adapter
+
+    return best_adapter
+
+
+def make_device_for_adapter(
+    device: BLEDevice,
+    adapter: str,
+) -> BLEDevice:
+    """Create a BLEDevice targeting a specific adapter.
+
+    Constructs a new ``BLEDevice`` with the D-Bus path pointing to the
+    chosen adapter, so that ``bleak-retry-connector`` connects through
+    it.
+
+    Parameters
+    ----------
+    device:
+        The original BLEDevice (from scanning).
+    adapter:
+        The adapter to target (e.g. ``"hci0"``).
+
+    Returns a new BLEDevice with the adapter-specific path.
+    """
+    from .bluez import address_to_bluez_path
+
+    path = address_to_bluez_path(device.address, adapter)
+    details: dict[str, Any] = {"path": path}
+
+    if isinstance(device.details, dict):
+        # Preserve any extra details from the original device
+        details.update(
+            {k: v for k, v in device.details.items() if k != "path"}
+        )
+
+    return BLEDevice(
+        device.address,
+        device.name,
+        details,
+    )

--- a/dbus-serialbattery/ext/bleak_connection_manager/bluez.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/bluez.py
@@ -1,0 +1,928 @@
+"""BlueZ D-Bus utilities for connection state inspection.
+
+Provides functions to detect phantom/inactive BLE connections and
+construct BlueZ D-Bus object paths.  Uses the shared ``MessageBus``
+from :mod:`.dbus_bus` and raw ``bus.call()`` for all queries — no
+proxy objects, no introspection, no fire-and-forget ``AddMatch``.
+
+These functions fill a gap: ``bleak-retry-connector`` does not expose
+connection state inspection, and ``bleak`` itself does not provide
+phantom detection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from .const import IS_LINUX, AdapterScanState
+
+_LOGGER = logging.getLogger(__name__)
+
+# D-Bus constants
+_BLUEZ_SERVICE = "org.bluez"
+_DEVICE_INTERFACE = "org.bluez.Device1"
+_ADAPTER_INTERFACE = "org.bluez.Adapter1"
+_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+_OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
+
+
+def address_to_bluez_path(address: str, adapter: str = "hci0") -> str:
+    """Convert a BLE address + adapter to a BlueZ D-Bus object path.
+
+    Example::
+
+        >>> address_to_bluez_path("AA:BB:CC:DD:EE:FF", "hci0")
+        '/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF'
+    """
+    dev_part = f"dev_{address.upper().replace(':', '_')}"
+    return f"/org/bluez/{adapter}/{dev_part}"
+
+
+async def _get_device_properties(
+    address: str, adapter: str = "hci0"
+) -> dict[str, Any] | None:
+    """Fetch D-Bus properties for a BLE device.
+
+    Returns a dict of property name → value, or ``None`` if the device
+    is not found on D-Bus.
+    """
+    if not IS_LINUX:
+        return None
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        _LOGGER.debug("dbus-fast not available, cannot query D-Bus")
+        return None
+
+    path = address_to_bluez_path(address, adapter)
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=path,
+                interface=_PROPERTIES_INTERFACE,
+                member="GetAll",
+                signature="s",
+                body=[_DEVICE_INTERFACE],
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            return None
+        return {k: v.value for k, v in reply.body[0].items()}
+    except Exception:
+        _LOGGER.debug(
+            "Failed to get D-Bus properties for %s on %s",
+            address,
+            adapter,
+            exc_info=True,
+        )
+        return None
+
+
+async def is_inactive_connection(
+    address: str, adapter: str = "hci0"
+) -> bool:
+    """Check whether a device has an inactive BLE connection.
+
+    An inactive connection is one where BlueZ D-Bus reports
+    ``Connected=True`` but ``ServicesResolved`` is not ``True``.
+    This indicates GATT discovery never completed — typically because
+    the HCI transport died after the initial connection event.
+
+    Parameters
+    ----------
+    address:
+        The BLE device MAC address (e.g. ``"AA:BB:CC:DD:EE:FF"``).
+    adapter:
+        The adapter name (e.g. ``"hci0"``).
+
+    Returns ``True`` if the connection is inactive (phantom).
+    """
+    if not IS_LINUX:
+        return False
+
+    props = await _get_device_properties(address, adapter)
+    if props is None:
+        return False
+
+    connected = props.get("Connected", False)
+    if not connected:
+        return False
+
+    services_resolved = props.get("ServicesResolved", False)
+    if services_resolved is not True:
+        _LOGGER.debug(
+            "%s: Inactive connection detected — Connected but "
+            "ServicesResolved is not True",
+            address,
+        )
+        return True
+
+    return False
+
+
+async def remove_device(address: str, adapter: str = "hci0") -> bool:
+    """Remove a device from BlueZ via the adapter's RemoveDevice method.
+
+    This is the D-Bus equivalent of ``bluetoothctl remove <address>``.
+    Clears all cached state including GATT services.
+
+    Returns ``True`` if the device was removed successfully.
+    """
+    if not IS_LINUX:
+        return False
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return False
+
+    adapter_path = f"/org/bluez/{adapter}"
+    device_path = address_to_bluez_path(address, adapter)
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=adapter_path,
+                interface=_ADAPTER_INTERFACE,
+                member="RemoveDevice",
+                signature="o",
+                body=[device_path],
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            _LOGGER.debug(
+                "RemoveDevice D-Bus error for %s: %s",
+                address,
+                reply.body[0] if reply.body else "unknown",
+            )
+            return False
+        _LOGGER.debug("Removed device %s from %s", address, adapter)
+        return True
+    except Exception:
+        _LOGGER.debug(
+            "Failed to remove %s from %s",
+            address,
+            adapter,
+            exc_info=True,
+        )
+        return False
+
+
+async def disconnect_device(address: str, adapter: str = "hci0") -> bool:
+    """Disconnect a device via D-Bus.
+
+    Returns ``True`` if the disconnect was initiated successfully.
+    """
+    if not IS_LINUX:
+        return False
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return False
+
+    path = address_to_bluez_path(address, adapter)
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=path,
+                interface=_DEVICE_INTERFACE,
+                member="Disconnect",
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            _LOGGER.debug(
+                "Disconnect D-Bus error for %s: %s",
+                address,
+                reply.body[0] if reply.body else "unknown",
+            )
+            return False
+        _LOGGER.debug("Disconnected %s on %s via D-Bus", address, adapter)
+        return True
+    except Exception:
+        _LOGGER.debug(
+            "Failed to disconnect %s on %s",
+            address,
+            adapter,
+            exc_info=True,
+        )
+        return False
+
+
+async def verified_disconnect(
+    address: str,
+    adapter: str = "hci0",
+    timeout: float = 5.0,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Disconnect a device and verify the D-Bus ``Connected`` property is ``False``.
+
+    Unlike :func:`disconnect_device`, this function polls the D-Bus
+    ``Connected`` property after initiating the disconnect to confirm
+    the device is truly disconnected.  If ``Connected`` remains ``True``
+    after *timeout* seconds, it escalates to :func:`remove_device` to
+    force-clear the stale BlueZ state.
+
+    This addresses Stuck State 8 (disconnect hang) without using
+    ``hcitool`` — purely via D-Bus.
+
+    Parameters
+    ----------
+    address:
+        The BLE device MAC address.
+    adapter:
+        The adapter name (e.g. ``"hci0"``).
+    timeout:
+        Maximum seconds to wait for ``Connected`` to become ``False``.
+    poll_interval:
+        Seconds between D-Bus property polls.
+
+    Returns ``True`` if the device is confirmed disconnected, ``False``
+    if the disconnect could not be verified (but cleanup was attempted).
+    """
+    if not IS_LINUX:
+        return True
+
+    # Step 1: Initiate disconnect via D-Bus
+    await disconnect_device(address, adapter)
+
+    # Step 2: Poll D-Bus Connected property
+    elapsed = 0.0
+    while elapsed < timeout:
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+        props = await _get_device_properties(address, adapter)
+        if props is None:
+            # Device no longer on D-Bus — fully disconnected
+            return True
+        if not props.get("Connected", False):
+            _LOGGER.debug(
+                "%s: Verified disconnected on %s after %.1f s",
+                address,
+                adapter,
+                elapsed,
+            )
+            return True
+
+    # Step 3: Still connected after timeout — escalate to remove
+    _LOGGER.warning(
+        "%s: Still Connected=True on %s after %.1f s disconnect timeout, "
+        "escalating to remove_device",
+        address,
+        adapter,
+        timeout,
+    )
+    await remove_device(address, adapter)
+    return False
+
+
+# ── Adapter health check for scan readiness ────────────────────────
+#
+# Pre-scan detection and repair of stale BlueZ adapter state that
+# causes ``InProgress`` errors on ``StartDiscovery``.
+
+# Per-adapter cooldown tracking for power-cycle operations.
+# Prevents rapid cascading power-cycles when multiple processes
+# detect stale state within a short window.
+_POWER_CYCLE_COOLDOWN = 30.0
+_last_power_cycle: dict[str, float] = {}
+
+# Settle time after power-cycling an adapter.  The adapter goes
+# through power-off → power-on → BlueZ re-initialization.
+_POWER_CYCLE_SETTLE = 2.0
+
+
+async def get_adapter_discovering(adapter: str) -> bool | None:
+    """Query the ``Discovering`` property of a BlueZ adapter.
+
+    Returns ``True`` if the adapter is actively discovering,
+    ``False`` if not, or ``None`` if the query failed.
+    """
+    if not IS_LINUX:
+        return None
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return None
+
+    adapter_path = f"/org/bluez/{adapter}"
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=adapter_path,
+                interface=_PROPERTIES_INTERFACE,
+                member="Get",
+                signature="ss",
+                body=[_ADAPTER_INTERFACE, "Discovering"],
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            return None
+        val = reply.body[0]
+        if hasattr(val, "value"):
+            val = val.value
+        return bool(val)
+    except Exception:
+        _LOGGER.debug(
+            "Failed to query Discovering on %s", adapter, exc_info=True,
+        )
+        return None
+
+
+async def _get_adapter_powered(adapter: str) -> bool | None:
+    """Read the ``Powered`` property of a BlueZ adapter.
+
+    Returns ``True``/``False`` or ``None`` on error.
+    """
+    if not IS_LINUX:
+        return None
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return None
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=f"/org/bluez/{adapter}",
+                interface=_PROPERTIES_INTERFACE,
+                member="Get",
+                signature="ss",
+                body=[_ADAPTER_INTERFACE, "Powered"],
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            return None
+        val = reply.body[0]
+        if hasattr(val, "value"):
+            val = val.value
+        return bool(val)
+    except Exception:
+        _LOGGER.debug(
+            "Failed to read Powered on %s", adapter, exc_info=True,
+        )
+        return None
+
+
+async def _set_adapter_powered(adapter: str, powered: bool) -> bool:
+    """Set the ``Powered`` property via D-Bus.
+
+    Returns ``True`` if the call succeeded, ``False`` on error.
+    """
+    if not IS_LINUX:
+        return False
+    try:
+        from dbus_fast import Message, MessageType, Variant
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return False
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=f"/org/bluez/{adapter}",
+                interface=_PROPERTIES_INTERFACE,
+                member="Set",
+                signature="ssv",
+                body=[_ADAPTER_INTERFACE, "Powered", Variant("b", powered)],
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            _LOGGER.warning(
+                "%s: Failed to set Powered=%s: %s",
+                adapter,
+                powered,
+                reply.body[0] if reply.body else "unknown",
+            )
+            return False
+        return True
+    except Exception:
+        _LOGGER.debug(
+            "Failed to set Powered=%s on %s", powered, adapter, exc_info=True,
+        )
+        return False
+
+
+def _hciconfig_up(adapter: str) -> bool:
+    """Bring an adapter up via ``hciconfig`` as a subprocess fallback.
+
+    This bypasses BlueZ's D-Bus path and talks directly to the kernel,
+    which succeeds even when the D-Bus ``Powered=True`` fails (e.g.
+    after an HCI_Reset timeout).
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["hciconfig", adapter, "up"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            _LOGGER.info(
+                "%s: Brought adapter up via hciconfig fallback", adapter,
+            )
+            return True
+        _LOGGER.warning(
+            "%s: hciconfig up failed (rc=%d): %s",
+            adapter,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return False
+    except Exception:
+        _LOGGER.warning(
+            "%s: hciconfig up subprocess failed", adapter, exc_info=True,
+        )
+        return False
+
+
+async def power_cycle_adapter(adapter: str) -> bool:
+    """Power-cycle a BlueZ adapter via D-Bus ``Powered`` property.
+
+    Sets ``Powered=False``, waits briefly, then ``Powered=True``.
+    This drops ALL connections and discovery sessions on the adapter,
+    clearing any stale BlueZ state.
+
+    After setting ``Powered=True``, verifies the adapter actually
+    came back up.  If D-Bus power-on fails (e.g. HCI_Reset timeout
+    left the controller in a bad state), retries once via D-Bus
+    then falls back to ``hciconfig <adapter> up``.
+
+    Returns ``True`` if the adapter is powered on when this function
+    returns, ``False`` if all recovery attempts failed.
+    """
+    if not IS_LINUX:
+        return False
+
+    # ── Step 1: Power off ──────────────────────────────────────────
+    if not await _set_adapter_powered(adapter, False):
+        return False
+
+    await asyncio.sleep(0.5)
+
+    # ── Step 2: Power on with verification ─────────────────────────
+    await _set_adapter_powered(adapter, True)
+
+    await asyncio.sleep(0.5)
+    powered = await _get_adapter_powered(adapter)
+    if powered is True:
+        _LOGGER.info("%s: Power-cycled adapter via D-Bus", adapter)
+        await asyncio.sleep(_POWER_CYCLE_SETTLE)
+        return True
+
+    # ── Step 3: D-Bus retry ────────────────────────────────────────
+    _LOGGER.warning(
+        "%s: Adapter still DOWN after Powered=True, retrying D-Bus", adapter,
+    )
+    await asyncio.sleep(1.0)
+    await _set_adapter_powered(adapter, True)
+    await asyncio.sleep(0.5)
+    powered = await _get_adapter_powered(adapter)
+    if powered is True:
+        _LOGGER.info("%s: Power-cycled adapter via D-Bus (retry succeeded)", adapter)
+        await asyncio.sleep(_POWER_CYCLE_SETTLE)
+        return True
+
+    # ── Step 4: hciconfig fallback ─────────────────────────────────
+    _LOGGER.warning(
+        "%s: D-Bus Powered=True failed twice, falling back to hciconfig",
+        adapter,
+    )
+    await asyncio.to_thread(_hciconfig_up, adapter)
+    await asyncio.sleep(1.0)
+    powered = await _get_adapter_powered(adapter)
+    if powered is True:
+        _LOGGER.info(
+            "%s: Adapter recovered via hciconfig fallback", adapter,
+        )
+        await asyncio.sleep(_POWER_CYCLE_SETTLE)
+        return True
+
+    _LOGGER.error(
+        "%s: Adapter LEFT DOWN after all recovery attempts — "
+        "manual intervention may be required",
+        adapter,
+    )
+    return False
+
+
+async def ensure_bluetoothd() -> bool:
+    """Self-heal: restart ``bluetoothd`` if it has crashed.
+
+    Lightweight check called at the start of scan operations (via
+    :func:`ensure_adapters_up`) to detect a dead ``bluetoothd`` between
+    scan cycles.  Uses a pure ``/proc`` scan — no D-Bus round-trip —
+    so cost is negligible when ``bluetoothd`` is healthy.
+
+    If ``bluetoothd`` is dead, attempts to restart it and waits up to
+    15 seconds for it to register on D-Bus.
+
+    Returns ``True`` if ``bluetoothd`` is running when the function
+    returns (whether it was already running or freshly started).
+    """
+    if not IS_LINUX:
+        return True
+
+    from .recovery import is_bluetoothd_alive, restart_bluetoothd
+
+    if is_bluetoothd_alive():
+        return True
+
+    _LOGGER.warning("bluetoothd is not running — attempting restart")
+
+    if not await restart_bluetoothd():
+        _LOGGER.error("Failed to restart bluetoothd")
+        return False
+
+    from .dbus_bus import wait_for_bluez
+
+    if await wait_for_bluez(timeout=15.0):
+        _LOGGER.info("bluetoothd restarted and BlueZ is back on D-Bus")
+        return True
+
+    _LOGGER.error("bluetoothd restarted but BlueZ did not appear on D-Bus")
+    return False
+
+
+async def ensure_adapters_up(adapters: list[str]) -> None:
+    """Self-heal: bring up any adapters that are currently DOWN.
+
+    Called at the start of scan operations to recover from failed
+    power-cycles or other conditions that left an adapter powered off.
+    Also verifies that ``bluetoothd`` is running and restarts it if needed.
+    Tries D-Bus first, then falls back to ``hciconfig`` if needed.
+    """
+    if not IS_LINUX:
+        return
+
+    await ensure_bluetoothd()
+
+    for adapter in adapters:
+        powered = await _get_adapter_powered(adapter)
+        if powered is False:
+            _LOGGER.warning(
+                "%s: Adapter is DOWN, attempting self-heal", adapter,
+            )
+            if await _set_adapter_powered(adapter, True):
+                await asyncio.sleep(0.5)
+                powered = await _get_adapter_powered(adapter)
+            if powered is not True:
+                _LOGGER.warning(
+                    "%s: D-Bus power-on failed, trying hciconfig", adapter,
+                )
+                await asyncio.to_thread(_hciconfig_up, adapter)
+                await asyncio.sleep(1.0)
+                powered = await _get_adapter_powered(adapter)
+            if powered is True:
+                _LOGGER.info("%s: Self-healed — adapter is back UP", adapter)
+            else:
+                _LOGGER.error(
+                    "%s: Self-heal FAILED — adapter remains DOWN", adapter,
+                )
+
+
+async def _power_cycle_adapter_with_cooldown(adapter: str) -> bool:
+    """Power-cycle an adapter, respecting a per-adapter cooldown.
+
+    If the adapter was power-cycled less than ``_POWER_CYCLE_COOLDOWN``
+    seconds ago, skip the cycle and return ``False``.  This prevents
+    rapid cascading cycles when multiple processes detect stale state
+    within a short window.
+
+    Before cycling, queries D-Bus for active connections on the adapter
+    and logs a WARNING listing affected devices.  The caller is
+    responsible for deciding that power-cycling is necessary (e.g. no
+    other adapter available); this function always proceeds if the
+    cooldown allows.
+
+    Returns ``True`` if the power-cycle ran, ``False`` if skipped or
+    failed.
+    """
+    now = time.monotonic()
+    last = _last_power_cycle.get(adapter, 0.0)
+    if (now - last) < _POWER_CYCLE_COOLDOWN:
+        _LOGGER.debug(
+            "%s: Power-cycle cooldown active (%.0fs remaining)",
+            adapter,
+            _POWER_CYCLE_COOLDOWN - (now - last),
+        )
+        return False
+
+    connected = await get_connected_devices(adapter)
+    if connected:
+        _LOGGER.warning(
+            "%s: Power-cycling adapter with %d active connection(s) "
+            "that will be dropped: %s",
+            adapter,
+            len(connected),
+            ", ".join(connected),
+        )
+    else:
+        _LOGGER.debug("%s: No active connections, safe to power-cycle", adapter)
+
+    result = await power_cycle_adapter(adapter)
+    if result:
+        _last_power_cycle[adapter] = time.monotonic()
+    return result
+
+
+async def try_stop_discovery(adapter: str) -> bool:
+    """Attempt to clear a discovery session from our shared D-Bus bus.
+
+    BlueZ ties each discovery session to the D-Bus connection that
+    called ``StartDiscovery``.  If *our* bus started a session that
+    was never stopped (e.g. ``BleakScanner`` cancelled mid-scan),
+    calling ``StopDiscovery`` from the same bus will clear it.
+
+    If the orphaned session belongs to a *different* D-Bus connection,
+    this call will fail harmlessly with an error.
+
+    Returns ``True`` if ``StopDiscovery`` succeeded (session cleared),
+    ``False`` otherwise.
+    """
+    if not IS_LINUX:
+        return False
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return False
+
+    adapter_path = f"/org/bluez/{adapter}"
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=adapter_path,
+                interface=_ADAPTER_INTERFACE,
+                member="StopDiscovery",
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            _LOGGER.debug(
+                "%s: StopDiscovery from our bus failed (expected if "
+                "session belongs to another connection): %s",
+                adapter,
+                reply.body[0] if reply.body else "unknown",
+            )
+            return False
+        _LOGGER.info(
+            "%s: StopDiscovery from our bus succeeded — "
+            "cleared orphaned session without power-cycle",
+            adapter,
+        )
+        return True
+    except Exception:
+        _LOGGER.debug(
+            "%s: StopDiscovery call failed", adapter, exc_info=True,
+        )
+        return False
+
+
+async def get_connected_devices(adapter: str) -> list[str]:
+    """Return MAC addresses of devices connected on *adapter*.
+
+    Queries BlueZ ``GetManagedObjects`` and filters for
+    ``org.bluez.Device1`` entries under this adapter where
+    ``Connected=True``.
+
+    Returns an empty list on error or non-Linux platforms.
+    """
+    if not IS_LINUX:
+        return []
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return []
+
+    adapter_prefix = f"/org/bluez/{adapter}/"
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path="/",
+                interface=_OBJECT_MANAGER_INTERFACE,
+                member="GetManagedObjects",
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            return []
+
+        connected: list[str] = []
+        objects = reply.body[0]
+        for path, interfaces in objects.items():
+            if not path.startswith(adapter_prefix):
+                continue
+            dev_props = interfaces.get(_DEVICE_INTERFACE)
+            if dev_props is None:
+                continue
+            conn_val = dev_props.get("Connected")
+            if conn_val is not None and hasattr(conn_val, "value"):
+                conn_val = conn_val.value
+            if conn_val is True:
+                addr_val = dev_props.get("Address")
+                if addr_val is not None and hasattr(addr_val, "value"):
+                    addr_val = addr_val.value
+                if isinstance(addr_val, str):
+                    connected.append(addr_val)
+        return connected
+    except Exception:
+        _LOGGER.debug(
+            "%s: Failed to enumerate connected devices",
+            adapter,
+            exc_info=True,
+        )
+        return []
+
+
+async def _probe_start_discovery(adapter: str) -> bool | None:
+    """Probe whether ``StartDiscovery`` works on an adapter.
+
+    Calls ``StartDiscovery`` on the shared D-Bus bus.  If it succeeds,
+    immediately calls ``StopDiscovery`` to clean up.
+
+    Returns:
+    - ``True`` if the adapter is clean (StartDiscovery succeeded).
+    - ``False`` if ``InProgress`` was returned (stale internal state).
+    - ``None`` on other errors (e.g. adapter not ready).
+
+    Must be called **while holding the scan lock** to prevent
+    interference from other processes.
+    """
+    if not IS_LINUX:
+        return None
+
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return None
+
+    adapter_path = f"/org/bluez/{adapter}"
+
+    try:
+        bus = await get_bus()
+
+        reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=adapter_path,
+                interface=_ADAPTER_INTERFACE,
+                member="StartDiscovery",
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            error_body = reply.body[0] if reply.body else ""
+            error_name = getattr(reply, "error_name", "") or ""
+            if "InProgress" in error_name or "InProgress" in str(error_body):
+                return False
+            _LOGGER.debug(
+                "%s: StartDiscovery probe error: %s (%s)",
+                adapter,
+                error_name,
+                error_body,
+            )
+            return None
+
+        # Probe succeeded — adapter is clean.  Stop our test session.
+        stop_reply = await bus.call(
+            Message(
+                destination=_BLUEZ_SERVICE,
+                path=adapter_path,
+                interface=_ADAPTER_INTERFACE,
+                member="StopDiscovery",
+            )
+        )
+        if stop_reply.message_type == MessageType.ERROR:
+            _LOGGER.debug(
+                "%s: StopDiscovery after probe failed (non-critical)",
+                adapter,
+            )
+        return True
+
+    except Exception:
+        _LOGGER.debug(
+            "%s: StartDiscovery probe failed", adapter, exc_info=True,
+        )
+        return None
+
+
+async def ensure_adapter_scan_ready(adapter: str) -> AdapterScanState:
+    """Pre-scan health check: detect and repair stale adapter state.
+
+    Uses a tiered recovery strategy that avoids power-cycling
+    whenever possible:
+
+    **Tier 1** — Try ``StopDiscovery`` from our shared D-Bus bus.
+    If the orphaned session belongs to *our* bus, this clears it
+    without disrupting any connections.
+
+    **Tier 2** — If Tier 1 fails, return a non-READY state so the
+    scanner can adapt.  The caller is responsible for deciding
+    whether to cache-poll, rotate, or escalate.
+
+    This function never power-cycles the adapter directly.  That
+    decision is deferred to the scanner loop which has visibility
+    into whether alternative adapters are available and whether
+    the stuck adapter has active connections.
+
+    Returns
+    -------
+    AdapterScanState
+        ``READY`` if the adapter can scan normally.
+        ``STUCK`` if ``Discovering=True`` and can't be cleared
+        (orphaned BlueZ session — rotation/power-cycle may help).
+        ``EXTERNAL_SCAN`` if ``Discovering=False`` but
+        ``StartDiscovery`` returns ``InProgress`` (external raw
+        HCI scan corruption — cache polling is the correct
+        response, power-cycling is futile).
+    """
+    if not IS_LINUX:
+        return AdapterScanState.READY
+
+    # ── Check 1: Orphaned Discovering=True ─────────────────────────
+    discovering = await get_adapter_discovering(adapter)
+
+    if discovering is True:
+        _LOGGER.warning(
+            "%s: Discovering=True with scan lock held — "
+            "orphaned scan session, attempting StopDiscovery",
+            adapter,
+        )
+        await try_stop_discovery(adapter)
+
+        discovering = await get_adapter_discovering(adapter)
+        if discovering is True:
+            _LOGGER.warning(
+                "%s: Still Discovering=True after StopDiscovery — "
+                "session belongs to another D-Bus connection",
+                adapter,
+            )
+            return AdapterScanState.STUCK
+        return AdapterScanState.READY
+
+    # ── Check 2: Hidden stale InProgress ───────────────────────────
+    probe_ok = await _probe_start_discovery(adapter)
+
+    if probe_ok is False:
+        _LOGGER.warning(
+            "%s: Discovering=False but StartDiscovery returns InProgress "
+            "— likely external raw HCI scan corruption",
+            adapter,
+        )
+        await try_stop_discovery(adapter)
+
+        probe_ok = await _probe_start_discovery(adapter)
+        if probe_ok is False:
+            _LOGGER.warning(
+                "%s: Still InProgress after StopDiscovery — "
+                "external scan active, will use cache polling",
+                adapter,
+            )
+            return AdapterScanState.EXTERNAL_SCAN
+
+    return AdapterScanState.READY

--- a/dbus-serialbattery/ext/bleak_connection_manager/connection.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/connection.py
@@ -1,0 +1,655 @@
+"""Outer retry loop wrapping bleak-retry-connector.
+
+This is the core of ``bleak-connection-manager``.  It calls
+``bleak_retry_connector.establish_connection(max_attempts=1)`` inside
+its own retry loop, adding all the BlueZ workarounds between attempts:
+
+- Per-device in-process lock (pre-attempt)
+- Cross-process slot-based adapter locking (per-attempt)
+- Phantom/inactive connection cleanup (pre-attempt)
+- Adapter rotation (per-attempt)
+- InProgress classification (post-failure)
+- Stuck-state diagnosis + targeted fix (post-failure)
+- Escalation chain (post-failure)
+- Clear stale BlueZ state (post-failure)
+- Post-connect validation (post-success)
+- Thread-level safety timer (per-attempt)
+
+Each workaround is independently removable.  When upstream or BlueZ
+fixes the root cause, the corresponding code path can be deleted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import weakref
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from bleak import BleakClient
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+
+from .adapters import discover_adapters, make_device_for_adapter, pick_adapter
+from .bluez import (
+    disconnect_device,
+    is_inactive_connection,
+    remove_device,
+    verified_disconnect,
+)
+from .const import (
+    DEFAULT_MAX_ATTEMPTS,
+    DISCONNECT_TIMEOUT,
+    IS_LINUX,
+    THREAD_SAFETY_TIMEOUT,
+    LockConfig,
+)
+from .diagnostics import StuckState, clear_stuck_state, diagnose_stuck_state
+from .hci import cancel_le_connect as _hci_cancel_le_connect
+from .lock import acquire_slot, release_slot
+from .recovery import (
+    EscalationAction,
+    EscalationConfig,
+    EscalationPolicy,
+    reset_adapter,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# ── Per-device in-process lock ─────────────────────────────────────
+#
+# Prevents two coroutines within the same process from racing to
+# connect to the same BLE device simultaneously.  This is a common
+# source of InProgress errors when a watchdog reconnect fires while
+# a scheduled reconnect is already underway.
+#
+# Uses a WeakValueDictionary so locks for devices that are no longer
+# referenced are garbage-collected automatically.
+
+_device_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+    weakref.WeakValueDictionary()
+)
+_device_locks_guard = asyncio.Lock()
+
+
+async def _get_device_lock(address: str) -> asyncio.Lock:
+    """Get or create an asyncio.Lock for a specific BLE device address.
+
+    Thread-safe within the asyncio event loop.  Locks are weakly
+    referenced — once all callers release their reference, the lock
+    is garbage-collected.
+    """
+    addr = address.upper()
+    lock = _device_locks.get(addr)
+    if lock is not None:
+        return lock
+
+    async with _device_locks_guard:
+        # Double-check after acquiring guard
+        lock = _device_locks.get(addr)
+        if lock is not None:
+            return lock
+        lock = asyncio.Lock()
+        _device_locks[addr] = lock
+        return lock
+
+
+# Upstream exceptions we catch to decide retry behavior
+try:
+    from bleak_retry_connector import (
+        BleakAbortedError,
+        BleakNotFoundError,
+        establish_connection as _brc_establish_connection,
+    )
+except ImportError as _exc:
+    raise ImportError(
+        "bleak-retry-connector is required: pip install bleak-retry-connector"
+    ) from _exc
+
+# Also import clear_cache and close_stale_connections from upstream
+try:
+    from bleak_retry_connector import clear_cache as _brc_clear_cache
+except ImportError:
+    _brc_clear_cache = None  # type: ignore[assignment]
+
+try:
+    from bleak_retry_connector import close_stale_connections as _brc_close_stale
+except ImportError:
+    _brc_close_stale = None  # type: ignore[assignment]
+
+
+async def _safe_validate(
+    validate_connection: Callable[[BleakClient], Awaitable[bool]],
+    client: BleakClient,
+) -> bool:
+    """Run the validation callback, catching all exceptions."""
+    try:
+        return await validate_connection(client)
+    except Exception:
+        _LOGGER.debug(
+            "validate_connection raised an exception, treating as failed",
+            exc_info=True,
+        )
+        return False
+
+
+async def _clear_inactive_connections(
+    device: BLEDevice, adapter: str, adapters: list[str] | None = None,
+) -> None:
+    """Clear phantom/inactive connections before a connection attempt.
+
+    Checks both the D-Bus layer and HCI layer:
+    1. D-Bus inactive connection check (Connected=True, ServicesResolved!=True)
+    2. Orphan HCI handle check (HCI handle exists, D-Bus disagrees)
+    """
+    try:
+        inactive = await is_inactive_connection(device.address, adapter)
+        if inactive:
+            _LOGGER.info(
+                "%s: Clearing inactive connection on %s before attempt",
+                device.address,
+                adapter,
+            )
+            await disconnect_device(device.address, adapter)
+            await remove_device(device.address, adapter)
+            await asyncio.sleep(0.5)
+            return
+    except Exception:
+        _LOGGER.debug(
+            "Failed to clear inactive connections for %s",
+            device.address,
+            exc_info=True,
+        )
+
+    # Full cross-layer diagnostics to catch orphan HCI handles
+    # that D-Bus doesn't know about (Stuck State 20)
+    try:
+        search_adapters = adapters if adapters else [adapter]
+        state = await diagnose_stuck_state(
+            device.address, adapter, adapters=search_adapters
+        )
+        # Only clear actual connection anomalies pre-attempt.
+        # STALE_CACHE (device in D-Bus, not connected, no HCI handle)
+        # is the normal state of a freshly-scanned device — clearing it
+        # here would invalidate the BLEDevice reference and cause the
+        # connection attempt to fail with "device disappeared".
+        # STALE_CACHE is handled post-failure instead.
+        if state not in (StuckState.NOT_STUCK, StuckState.STALE_CACHE):
+            _LOGGER.info(
+                "%s: Pre-attempt diagnostics found %s, clearing",
+                device.address,
+                state.value,
+            )
+            await clear_stuck_state(
+                device.address, adapter, state, adapters=search_adapters
+            )
+            await asyncio.sleep(0.5)
+    except Exception:
+        _LOGGER.debug(
+            "Failed cross-layer diagnostics for %s",
+            device.address,
+            exc_info=True,
+        )
+
+
+async def _clear_stale_state(device: BLEDevice) -> None:
+    """Clear stale BlueZ state using upstream utility if available."""
+    if _brc_clear_cache is not None:
+        try:
+            await _brc_clear_cache(device.address)
+        except Exception:
+            _LOGGER.debug(
+                "clear_cache failed for %s",
+                device.address,
+                exc_info=True,
+            )
+    else:
+        await remove_device(device.address)
+
+
+async def _handle_inprogress(
+    device: BLEDevice, adapter: str = "hci0"
+) -> None:
+    """Handle an InProgress error by cancelling at HCI and clearing D-Bus.
+
+    Order of operations:
+    1. Cancel pending LE Create Connection at HCI level (State 3 fix)
+    2. Close stale connections via upstream utility
+    3. Clear stale D-Bus cache
+    """
+    _LOGGER.debug(
+        "%s: InProgress error on %s — cancelling LE connect and clearing state",
+        device.address,
+        adapter,
+    )
+    # Step 1: Cancel at HCI level — this is safe even if no LE connect
+    # is pending (controller returns Command Disallowed, which we ignore)
+    try:
+        await asyncio.to_thread(_hci_cancel_le_connect, adapter)
+    except Exception:
+        _LOGGER.debug(
+            "HCI LE cancel failed for %s on %s",
+            device.address,
+            adapter,
+            exc_info=True,
+        )
+
+    # Step 2: Close stale connections via upstream
+    if _brc_close_stale is not None:
+        try:
+            await _brc_close_stale(device)
+        except Exception:
+            _LOGGER.debug(
+                "close_stale_connections failed for %s",
+                device.address,
+                exc_info=True,
+            )
+
+    # Step 3: Clear D-Bus cache
+    await _clear_stale_state(device)
+
+
+async def _execute_escalation(
+    action: EscalationAction,
+    adapter: str,
+    device: BLEDevice,
+    escalation_policy: EscalationPolicy | None,
+    adapters: list[str] | None = None,
+) -> None:
+    """Execute the escalation action recommended by the policy."""
+    if action == EscalationAction.RETRY:
+        return
+
+    if action == EscalationAction.DIAGNOSE:
+        state = await diagnose_stuck_state(
+            device.address, adapter, adapters=adapters
+        )
+        # Only clear actual connection anomalies, not STALE_CACHE.
+        # STALE_CACHE is the normal state of a freshly-scanned device;
+        # removing it invalidates the BLEDevice reference.
+        if state not in (StuckState.NOT_STUCK, StuckState.STALE_CACHE):
+            await clear_stuck_state(
+                device.address, adapter, state, adapters=adapters
+            )
+        return
+
+    if action == EscalationAction.CLEAR_BLUEZ:
+        await _clear_stale_state(device)
+        return
+
+    if action == EscalationAction.ROTATE_ADAPTER:
+        # Rotation is handled by pick_adapter in the main loop
+        return
+
+    if action == EscalationAction.RESET_ADAPTER:
+        _LOGGER.warning(
+            "Escalation: resetting adapter %s after repeated failures",
+            adapter,
+        )
+        success = await reset_adapter(adapter)
+        if success and escalation_policy:
+            escalation_policy.record_reset(adapter)
+        return
+
+
+def _create_safety_timer(
+    timeout: float,
+    loop: asyncio.AbstractEventLoop,
+    connect_task: asyncio.Task[Any],
+) -> threading.Timer:
+    """Create a thread-level safety timer that cancels a stuck task.
+
+    This runs on a separate thread so it can fire even when the asyncio
+    event loop is blocked.  It's the last resort for Stuck State 6
+    (blocked asyncio event loop).
+    """
+
+    def _on_timer_expired() -> None:
+        if not connect_task.done():
+            _LOGGER.warning(
+                "Thread safety timer expired after %.0f s — "
+                "cancelling stuck connection task",
+                timeout,
+            )
+            loop.call_soon_threadsafe(connect_task.cancel)
+
+    timer = threading.Timer(timeout, _on_timer_expired)
+    timer.daemon = True
+    return timer
+
+
+async def establish_connection(
+    client_class: type[BleakClient],
+    device: BLEDevice,
+    name: str | None = None,
+    *,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    adapters: list[str] | None = None,
+    close_inactive_connections: bool = False,
+    safety_timer: bool = False,
+    try_direct_first: bool = False,
+    validate_connection: Callable[[BleakClient], Awaitable[bool]] | None = None,
+    lock_config: LockConfig | None = None,
+    escalation_policy: EscalationPolicy | None = None,
+    overall_timeout: float | None = None,
+    **kwargs: Any,
+) -> BleakClient:
+    """Establish a BLE connection with full lifecycle management.
+
+    Drop-in replacement for ``bleak_retry_connector.establish_connection()``
+    with additional BlueZ workarounds.
+
+    Parameters
+    ----------
+    client_class:
+        The BleakClient class (or subclass) to use.
+    device:
+        The BLE device to connect to.
+    name:
+        Device name for logging.
+    max_attempts:
+        Maximum number of outer retry attempts.
+    adapters:
+        List of adapters to rotate through.  If ``None``, auto-discovered.
+        Pass a single-element list to pin to one adapter.
+    close_inactive_connections:
+        If ``True``, detect and clear phantom connections before each
+        attempt.
+    safety_timer:
+        If ``True``, start a thread-level timer that cancels the
+        connection attempt if the asyncio event loop appears blocked.
+    try_direct_first:
+        If ``True``, the first attempt uses ``use_services_cache=True``
+        to try a direct connection from the BlueZ cache without scanning.
+        This is 2-5 s faster than scan + connect (10-15 s) for devices
+        that are already in the BlueZ cache.  Subsequent attempts revert
+        to the normal scan + connect flow.  Useful for connect-on-demand
+        services where latency matters.
+    validate_connection:
+        Optional async callback ``(client) -> bool`` called after a
+        successful connection.  If it returns ``False`` (or raises),
+        the connection is torn down and the next attempt starts.
+    lock_config:
+        Cross-process lock configuration.  If ``None`` or
+        ``enabled=False``, no locking is performed.
+    escalation_policy:
+        Failure escalation policy.  If ``None``, a default policy
+        with ``reset_adapter=False`` is used.
+    overall_timeout:
+        Hard ceiling (in seconds) for the entire connection process
+        including all retry attempts and escalation.  If ``None``
+        (the default), there is no overall timeout — only per-attempt
+        timeouts apply.  Recommended values: 240 s for critical BMS
+        connections, 300 s for sensors/switches.  When the timeout
+        fires, an ``asyncio.TimeoutError`` is raised.
+    **kwargs:
+        Additional keyword arguments passed through to
+        ``bleak_retry_connector.establish_connection()``.
+
+    Returns
+    -------
+    BleakClient
+        A connected BleakClient instance.
+
+    Raises
+    ------
+    BleakAbortedError
+        If all attempts are exhausted.
+    BleakNotFoundError
+        If the device cannot be found on any attempt.
+    """
+    display_name = name or device.name or device.address
+
+    async def _do_establish() -> BleakClient:
+        # Auto-discover adapters if not provided
+        nonlocal adapters
+        if adapters is None and IS_LINUX:
+            adapters = discover_adapters()
+
+        effective_adapters = adapters or ["hci0"]
+        loop = asyncio.get_running_loop()
+        last_error: Exception | None = None
+
+        # Per-device in-process lock — prevents two coroutines from
+        # racing to connect to the same BLE device simultaneously
+        device_lock = await _get_device_lock(device.address)
+
+        async with device_lock:
+            for attempt in range(1, max_attempts + 1):
+                adapter = pick_adapter(effective_adapters, attempt)
+
+                # --- Pre-attempt: phantom detection ---
+                if close_inactive_connections and IS_LINUX:
+                    await _clear_inactive_connections(
+                        device, adapter, adapters=effective_adapters
+                    )
+
+                # --- Adapter rotation: create device for this adapter ---
+                if len(effective_adapters) > 1:
+                    attempt_device = make_device_for_adapter(device, adapter)
+                else:
+                    attempt_device = device
+
+                # --- Cross-process slot-based lock ---
+                fd: int | None = None
+                if lock_config is not None:
+                    fd = await acquire_slot(lock_config, adapter)
+
+                timer: threading.Timer | None = None
+                try:
+                    # --- Single attempt via upstream bleak-retry-connector ---
+                    attempt_kwargs = dict(kwargs)
+                    if try_direct_first and attempt == 1:
+                        attempt_kwargs.setdefault("use_services_cache", True)
+                        _LOGGER.debug(
+                            "%s: Attempt 1 — trying direct connect (cache path)",
+                            display_name,
+                        )
+
+                    connect_coro = _brc_establish_connection(
+                        client_class,
+                        attempt_device,
+                        display_name,
+                        max_attempts=1,
+                        **attempt_kwargs,
+                    )
+
+                    if safety_timer:
+                        connect_task = asyncio.ensure_future(connect_coro)
+                        timer = _create_safety_timer(
+                            THREAD_SAFETY_TIMEOUT, loop, connect_task
+                        )
+                        timer.start()
+                        try:
+                            client = await connect_task
+                        finally:
+                            timer.cancel()
+                            timer = None
+                    else:
+                        client = await connect_coro
+
+                except BleakNotFoundError:
+                    # Must precede the BleakError clause below
+                    # (BleakNotFoundError subclasses BleakError) so the
+                    # documented not-found contract raises instead of
+                    # retrying through the escalation chain.
+                    raise
+
+                except (BleakError, BleakAbortedError, asyncio.TimeoutError, EOFError, BrokenPipeError, asyncio.CancelledError) as exc:
+                    if isinstance(exc, asyncio.CancelledError):
+                        # Only a cancel aimed at the inner connect task
+                        # (safety timer, or a CancelledError leaked from
+                        # bleak internals) is retryable.  A cancel of
+                        # *this* task — caller shutdown, or wait_for
+                        # enforcing overall_timeout — must propagate, or
+                        # the retry loop keeps the task alive against
+                        # the caller's will.  Task.cancelling() requires
+                        # Python 3.11; on older versions propagate every
+                        # cancel (conservative).
+                        current = asyncio.current_task()
+                        cancelling = getattr(current, "cancelling", None)
+                        if cancelling is None or cancelling() > 0:
+                            raise
+                    last_error = exc
+                    _LOGGER.debug(
+                        "%s: Attempt %d/%d on %s failed: %s",
+                        display_name,
+                        attempt,
+                        max_attempts,
+                        adapter,
+                        exc,
+                    )
+
+                    # --- InProgress classification ---
+                    if "InProgress" in str(exc):
+                        await _handle_inprogress(device, adapter)
+                    elif attempt == max_attempts:
+                        await _clear_stale_state(device)
+
+                    # --- Escalation ---
+                    if escalation_policy is not None:
+                        action = escalation_policy.on_failure(adapter)
+                        await _execute_escalation(
+                            action, adapter, device, escalation_policy,
+                            adapters=effective_adapters,
+                        )
+
+                    # Brief backoff before retry
+                    if attempt < max_attempts:
+                        await asyncio.sleep(0.25)
+
+                    continue
+
+                finally:
+                    if timer is not None:
+                        timer.cancel()
+                    release_slot(fd)
+
+                # --- Post-connect validation ---
+                if validate_connection is not None:
+                    valid = await _safe_validate(validate_connection, client)
+
+                    if not valid and IS_LINUX:
+                        # Some BLE devices (especially Telink-based chips)
+                        # report ServicesResolved before all GATT services
+                        # are registered on D-Bus.  The Generic Attribute
+                        # service appears first, then vendor-specific
+                        # services arrive 2-10s later via InterfacesAdded
+                        # or Service Changed indication.
+                        #
+                        # Wait with escalating delays and re-read the GATT
+                        # service table from BlueZ each time.
+                        cumulative = 0.0
+                        for retry_wait in (2.0, 4.0, 8.0):
+                            if not client.is_connected:
+                                _LOGGER.info(
+                                    "%s: BLE link dropped during GATT retry "
+                                    "wait, aborting re-validation",
+                                    display_name,
+                                )
+                                break
+
+                            cumulative += retry_wait
+                            _LOGGER.info(
+                                "%s: Attempt %d/%d on %s — validation failed, "
+                                "waiting %.0fs for late GATT services "
+                                "(%.0fs cumulative)",
+                                display_name,
+                                attempt,
+                                max_attempts,
+                                adapter,
+                                retry_wait,
+                                cumulative,
+                            )
+                            await asyncio.sleep(retry_wait)
+
+                            # Force bleak to re-read services from BlueZ.
+                            # Clear the backend's cached service collection
+                            # (not the wrapper's @property) so _get_services()
+                            # rebuilds it from BlueZ's current D-Bus state.
+                            try:
+                                client._backend.services = None  # type: ignore[union-attr]
+                                await client._backend._get_services(  # type: ignore[union-attr]
+                                    dangerous_use_bleak_cache=False,
+                                )
+                            except Exception:
+                                _LOGGER.warning(
+                                    "%s: _get_services() raised during GATT "
+                                    "re-read at %.0fs — will retry",
+                                    display_name,
+                                    cumulative,
+                                    exc_info=True,
+                                )
+                                continue
+
+                            valid = await _safe_validate(
+                                validate_connection, client,
+                            )
+                            if valid:
+                                _LOGGER.info(
+                                    "%s: Late GATT services appeared after "
+                                    "%.0fs — validation passed",
+                                    display_name,
+                                    cumulative,
+                                )
+                                break
+
+                    if not valid:
+                        _LOGGER.info(
+                            "%s: Attempt %d/%d on %s — validation failed "
+                            "after GATT retry, tearing down",
+                            display_name,
+                            attempt,
+                            max_attempts,
+                            adapter,
+                        )
+                        try:
+                            await asyncio.wait_for(
+                                client.disconnect(), timeout=DISCONNECT_TIMEOUT
+                            )
+                        except Exception:
+                            _LOGGER.debug(
+                                "Disconnect after failed validation raised",
+                                exc_info=True,
+                            )
+
+                        if IS_LINUX:
+                            await verified_disconnect(
+                                device.address,
+                                adapter,
+                                timeout=DISCONNECT_TIMEOUT,
+                            )
+
+                        await _clear_stale_state(device)
+                        if attempt < max_attempts:
+                            await asyncio.sleep(0.25)
+                        continue
+
+                # --- Success ---
+                if escalation_policy is not None:
+                    escalation_policy.on_success(adapter)
+
+                _LOGGER.debug(
+                    "%s: Connected on attempt %d/%d via %s",
+                    display_name,
+                    attempt,
+                    max_attempts,
+                    adapter,
+                )
+                return client
+
+        # All attempts exhausted
+        raise BleakAbortedError(
+            f"{display_name}: Failed to connect after {max_attempts} attempts"
+            + (f": {last_error}" if last_error else "")
+        )
+
+    # Apply overall_timeout if specified
+    if overall_timeout is not None:
+        _LOGGER.debug(
+            "%s: overall_timeout=%.0fs", display_name, overall_timeout,
+        )
+        return await asyncio.wait_for(_do_establish(), timeout=overall_timeout)
+    return await _do_establish()

--- a/dbus-serialbattery/ext/bleak_connection_manager/const.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/const.py
@@ -1,0 +1,142 @@
+"""Constants and configuration dataclasses for bleak-connection-manager."""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from enum import Enum
+
+IS_LINUX = platform.system() == "Linux"
+
+
+class AdapterScanState(Enum):
+    """Result of pre-scan adapter health check.
+
+    Returned by :func:`~bleak_connection_manager.bluez.ensure_adapter_scan_ready`
+    to tell the scanner how to proceed.
+    """
+
+    READY = "ready"
+    """Adapter can scan normally via ``StartDiscovery``."""
+
+    EXTERNAL_SCAN = "external_scan"
+    """An external process (e.g. ``dbus-ble-sensors``) is running raw HCI
+    scans that corrupt BlueZ's internal discovery state.  Pattern:
+    ``Discovering=False`` but ``StartDiscovery`` returns ``InProgress``.
+
+    The scanner should fall back to BlueZ cache polling — the external
+    scan continuously populates the cache via kernel mgmt events.
+    Power-cycling is futile because the external scanner re-corrupts
+    the state immediately."""
+
+    STUCK = "stuck"
+    """BlueZ-level orphaned discovery session (``Discovering=True`` that
+    cannot be cleared via ``StopDiscovery``).  The scanner should rotate
+    to another adapter and may escalate to power-cycling as a last resort."""
+
+# Thread-level safety timer timeout (seconds).  Must be less than
+# BLEAK_SAFETY_TIMEOUT (60 s in bleak-retry-connector) so the asyncio
+# timeout remains the primary mechanism and the thread timer is only
+# a fallback for a stuck event loop.
+THREAD_SAFETY_TIMEOUT = 45.0
+
+# How long to wait for a disconnect to complete before giving up.
+DISCONNECT_TIMEOUT = 5.0
+
+# Default number of outer retry attempts.
+DEFAULT_MAX_ATTEMPTS = 4
+
+
+@dataclass
+class LockConfig:
+    """Configuration for cross-process BLE serialization locks.
+
+    On multi-service systems (e.g. Venus OS / Cerbo GX) several processes
+    may compete for the same BLE adapter, causing ``InProgress`` errors
+    on ~40% of connection attempts.  Slot-based file locking limits
+    concurrent connection attempts per adapter across all processes.
+
+    All services sharing adapters on the same host **must** use the same
+    *lock_dir* and *lock_template* to coordinate.
+
+    Parameters
+    ----------
+    enabled:
+        Whether cross-process locking is active.
+    lock_dir:
+        Directory for lock files.  Defaults to ``/run`` — cleared on
+        reboot so stale locks cannot survive reboots.
+    lock_template:
+        Template with ``{adapter}`` and ``{slot}`` placeholders.
+    lock_timeout:
+        Maximum seconds to wait for slot acquisition.  If exceeded, the
+        connection attempt proceeds without a slot (graceful
+        degradation).
+    max_slots:
+        Maximum concurrent connection attempts allowed per adapter.
+        Each slot is a separate lock file.  ``1`` gives strict
+        serialization (old behavior).  ``2``-``3`` is typical for a
+        single adapter on a Cerbo GX.  Higher values suit systems
+        with multiple USB adapters.  ``flock`` is crash-safe — if a
+        process dies, the kernel releases its slot automatically.
+    """
+
+    enabled: bool = False
+    lock_dir: str = "/run"
+    lock_template: str = "bleak-cm-{adapter}-slot-{slot}.lock"
+    lock_timeout: float = 15.0
+    max_slots: int = 2
+
+    def path_for_slot(self, adapter: str | None, slot: int) -> str:
+        """Return the full lock file path for a given adapter slot."""
+        name = adapter or "default"
+        filename = self.lock_template.format(adapter=name, slot=slot)
+        return f"{self.lock_dir}/{filename}"
+
+    def path_for_adapter(self, adapter: str | None) -> str:
+        """Return the lock file path for slot 0 (backwards compatibility)."""
+        return self.path_for_slot(adapter, 0)
+
+
+@dataclass
+class ScanLockConfig:
+    """Configuration for per-adapter scan serialization.
+
+    Modern BlueZ (>= 5.50) merges discovery sessions across D-Bus
+    clients, so scans by *different processes* on the same adapter do
+    not conflict (verified on Venus OS v3.73 / BlueZ 5.72).  The real
+    ``org.bluez.Error.InProgress`` hazard is two concurrent scans in
+    the **same process**: they share bleak's D-Bus connection, and the
+    second ``StartDiscovery`` from the same client fails.
+
+    This config therefore controls an in-process per-adapter
+    ``asyncio.Lock`` (see :mod:`bleak_connection_manager.scan_lock`).
+    It was previously a cross-process file lock built on the incorrect
+    premise that BlueZ allows only one scan per adapter system-wide.
+
+    Parameters
+    ----------
+    enabled:
+        Whether per-adapter scan serialization is active.
+    lock_dir:
+        Deprecated — retained for API compatibility, no longer used
+        (locking is in-process; no lock files are created).
+    lock_template:
+        Deprecated — retained for API compatibility, no longer used.
+    lock_timeout:
+        Maximum seconds to wait for scan lock acquisition.  If exceeded,
+        the scan proceeds without holding the lock (graceful degradation)
+        so the caller can still attempt the scan and handle the
+        ``InProgress`` error itself.
+    """
+
+    enabled: bool = False
+    lock_dir: str = "/run"
+    lock_template: str = "bleak-cm-{adapter}-scan.lock"
+    lock_timeout: float = 30.0
+
+    def path_for_adapter(self, adapter: str | None) -> str:
+        """Return the full lock file path for a given adapter."""
+        name = adapter or "default"
+        filename = self.lock_template.format(adapter=name)
+        return f"{self.lock_dir}/{filename}"

--- a/dbus-serialbattery/ext/bleak_connection_manager/dbus_bus.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/dbus_bus.py
@@ -1,0 +1,352 @@
+"""Shared D-Bus system bus for BlueZ diagnostic queries.
+
+Provides a single long-lived ``MessageBus`` connection to the system
+D-Bus daemon, reused across all BCM diagnostic operations (device
+property queries, remove, disconnect, adapter state inspection, etc.).
+
+Why a shared bus?
+-----------------
+
+Previously, each diagnostic function created its own temporary
+``MessageBus``, used it for one query, and immediately disconnected.
+This caused two problems:
+
+1. **Spurious errors**: ``dbus-fast``'s ``get_proxy_object()`` triggers
+   ``_init_high_level_client()`` which fire-and-forgets an ``AddMatch``
+   for ``NameOwnerChanged``.  If the bus disconnects before the reply
+   arrives, the callback logs ``add match request failed`` at ERROR
+   level.
+
+2. **Unnecessary overhead**: Each temporary bus creates a Unix socket,
+   authenticates, and tears down.  For the shyion service polling 7
+   devices per hour, that was 14+ bus connections created and destroyed
+   per poll cycle.
+
+The shared bus eliminates both issues: the ``AddMatch`` (if it occurs)
+succeeds because the bus stays alive, and all queries reuse one
+connection.
+
+All functions use raw ``bus.call(Message(...))`` instead of proxy
+objects, which avoids triggering ``_init_high_level_client()`` entirely
+and also skips the unnecessary ``bus.introspect()`` round-trip.
+
+Thread / async safety
+---------------------
+
+The bus is lazily created on first use and auto-reconnects if the
+connection drops.  All access goes through :func:`get_bus`, which is
+safe to call from any coroutine in the same event loop.  There is no
+cross-thread sharing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from .const import IS_LINUX
+
+_LOGGER = logging.getLogger(__name__)
+
+_bus: object | None = None  # dbus_fast.aio.MessageBus, typed loosely to avoid import on non-Linux
+_bus_loop: object | None = None  # The event loop the bus was created on
+_bluez_ready = False  # Set True once we've confirmed org.bluez is on D-Bus
+
+# Rate-limit: after a confirmed wait_for_bluez() failure (bluetoothd dead
+# and restart unsuccessful), don't re-poll for this many seconds.  Prevents
+# rapid cycling that leaks D-Bus socket FDs in bleak/dbus_fast.
+_BLUEZ_FAILURE_COOLDOWN = 60.0
+_last_bluez_failure: float = 0.0
+
+
+def is_service_unknown_error(exc: BaseException) -> bool:
+    """Return True if *exc* is a D-Bus ServiceUnknown error (org.bluez not running)."""
+    msg = str(exc)
+    return "ServiceUnknown" in msg or "not provided by any .service files" in msg
+
+
+def mark_bluez_gone() -> None:
+    """Clear the BlueZ-ready flag so the next scan re-waits for bluetoothd.
+
+    Call this whenever a BLE operation fails with a ServiceUnknown error —
+    it means bluetoothd crashed at runtime and must come back before any
+    BlueZ operation can succeed.
+    """
+    global _bluez_ready
+    if _bluez_ready:
+        _LOGGER.warning(
+            "org.bluez is no longer on D-Bus (bluetoothd crashed?); "
+            "future scans will wait for it to restart"
+        )
+        _bluez_ready = False
+
+
+async def get_bus():
+    """Get the shared system D-Bus connection, creating or reconnecting as needed.
+
+    Returns a connected ``dbus_fast.aio.MessageBus`` instance.
+
+    If the running event loop differs from the one the bus was created
+    on, the old bus is discarded and a fresh one is created.  This
+    prevents ``Future attached to a different loop`` RuntimeErrors when
+    the caller's event loop changes (e.g. ``asyncio.run()`` creates a
+    new loop between calls).
+
+    Raises ``ImportError`` if ``dbus-fast`` is not available, or
+    ``RuntimeError`` on non-Linux platforms.
+    """
+    global _bus, _bus_loop
+
+    if not IS_LINUX:
+        raise RuntimeError("Shared D-Bus bus is only available on Linux")
+
+    from dbus_fast.aio import MessageBus
+    from dbus_fast.constants import BusType
+
+    current_loop = asyncio.get_running_loop()
+
+    if _bus is not None:
+        if _bus_loop is not current_loop:
+            _LOGGER.debug(
+                "Shared D-Bus bus was created on a different event loop, "
+                "reconnecting on current loop"
+            )
+            try:
+                _bus.disconnect()
+            except Exception:
+                pass
+            _bus = None
+        elif _bus.connected:
+            return _bus
+        else:
+            _LOGGER.debug("Shared D-Bus bus disconnected, reconnecting")
+            try:
+                _bus.disconnect()
+            except Exception:
+                pass
+
+    _bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+    _bus_loop = current_loop
+    _LOGGER.debug("Shared D-Bus bus connected")
+    return _bus
+
+
+async def _ping_bluez() -> bool:
+    """Single fast D-Bus check for ``org.bluez`` availability.
+
+    Returns ``True`` if BlueZ responded (any non-ServiceUnknown reply).
+    """
+    from dbus_fast import Message, MessageType
+
+    try:
+        bus = await get_bus()
+        reply = await bus.call(
+            Message(
+                destination="org.bluez",
+                path="/org/bluez",
+                interface="org.freedesktop.DBus.Properties",
+                member="GetAll",
+                signature="s",
+                body=["org.bluez.AgentManager1"],
+            )
+        )
+        if reply.message_type != MessageType.ERROR:
+            return True
+        error_name = reply.error_name or ""
+        if "ServiceUnknown" in error_name or "UnknownObject" in error_name:
+            return False
+        return True
+    except Exception:
+        return False
+
+
+async def _poll_bluez(timeout: float, poll_interval: float) -> bool:
+    """Poll D-Bus for ``org.bluez`` up to *timeout* seconds.
+
+    Returns ``True`` as soon as BlueZ responds, ``False`` on timeout.
+    """
+    elapsed = 0.0
+    while elapsed < timeout:
+        if await _ping_bluez():
+            if elapsed > 0:
+                _LOGGER.info("BlueZ ready on D-Bus after %.1fs", elapsed)
+            else:
+                _LOGGER.debug("BlueZ ready on D-Bus")
+            return True
+
+        _LOGGER.debug(
+            "Waiting for BlueZ on D-Bus (%.1fs / %.0fs)...",
+            elapsed, timeout,
+        )
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+        # Reconnect bus if it dropped while we were waiting
+        await get_bus()
+
+    return False
+
+
+async def wait_for_bluez(
+    timeout: float = 30.0,
+    poll_interval: float = 1.0,
+) -> bool:
+    """Wait until ``org.bluez`` is available on the system D-Bus.
+
+    On Venus OS, BLE services may start before ``bluetoothd`` has
+    registered on D-Bus.  Any BlueZ operation attempted before
+    ``org.bluez`` is available fails with::
+
+        org.freedesktop.DBus.Error.ServiceUnknown:
+        The name org.bluez was not provided by any .service files
+
+    This function polls D-Bus until ``org.bluez`` is reachable or
+    *timeout* seconds have elapsed.
+
+    If the initial poll times out, the function attempts to restart
+    ``bluetoothd`` via ``/etc/init.d/bluetooth start`` and polls for
+    an additional 10 seconds.
+
+    The ``_bluez_ready`` cache is validated with a single D-Bus ping
+    on every call, so a crashed ``bluetoothd`` is detected even when
+    the cache says BlueZ was previously healthy.
+
+    Returns ``True`` if BlueZ became available, ``False`` on timeout.
+    """
+    global _bluez_ready, _last_bluez_failure
+
+    if not IS_LINUX:
+        return True
+
+    # Rate-limit: if we recently confirmed BlueZ is dead and couldn't
+    # recover, don't burn CPU and FDs re-polling.  Return False
+    # immediately so the caller backs off.
+    if _last_bluez_failure > 0:
+        since_failure = time.monotonic() - _last_bluez_failure
+        if since_failure < _BLUEZ_FAILURE_COOLDOWN:
+            _LOGGER.debug(
+                "BlueZ failure cooldown: %.0fs remaining",
+                _BLUEZ_FAILURE_COOLDOWN - since_failure,
+            )
+            return False
+
+    # Validate the cache: if we previously marked BlueZ as ready,
+    # do a quick ping to confirm it's still alive.  This catches
+    # bluetoothd crashes that happened since the last successful check.
+    if _bluez_ready:
+        if await _ping_bluez():
+            return True
+        _LOGGER.warning(
+            "BlueZ was previously available but is no longer responding "
+            "on D-Bus — bluetoothd may have crashed"
+        )
+        _bluez_ready = False
+
+    # Normal poll loop (shortened to 5s — the full 30s poll is wasteful
+    # for a crashed daemon, and the restart below is the real fix)
+    if await _poll_bluez(min(timeout, 5.0), poll_interval):
+        _bluez_ready = True
+        _last_bluez_failure = 0.0
+        return True
+
+    # Poll exhausted — attempt recovery
+    _LOGGER.warning(
+        "BlueZ not on D-Bus — attempting recovery",
+    )
+
+    from .recovery import restart_bluetoothd
+
+    # Stop dbus-ble-sensors first if present — its raw HCI scanning
+    # is the primary cause of bluetoothd crashes on Venus OS.
+    await _stop_raw_hci_scanner()
+
+    if await restart_bluetoothd():
+        if await _poll_bluez(10.0, poll_interval):
+            _bluez_ready = True
+            _last_bluez_failure = 0.0
+            # Re-enable dbus-ble-sensors now that bluetoothd is healthy
+            await _start_raw_hci_scanner()
+            return True
+        _LOGGER.error(
+            "bluetoothd restarted but BlueZ still not on D-Bus after 10s"
+        )
+    else:
+        _LOGGER.error(
+            "Failed to restart bluetoothd — BLE operations will fail"
+        )
+
+    # Re-enable dbus-ble-sensors even on failure (don't leave it stopped)
+    await _start_raw_hci_scanner()
+
+    _last_bluez_failure = time.monotonic()
+    return False
+
+
+async def _stop_raw_hci_scanner() -> None:
+    """Stop ``dbus-ble-sensors`` if it exists.
+
+    On Venus OS, this Victron service uses raw HCI sockets for BLE
+    scanning, bypassing BlueZ entirely.  This corrupts BlueZ's
+    internal state and eventually crashes ``bluetoothd``.  Stopping it
+    before restarting ``bluetoothd`` prevents the new daemon from being
+    immediately killed again.
+
+    No-op if the service doesn't exist or ``svc`` is unavailable.
+    """
+    svc_dir = "/service/dbus-ble-sensors"
+    try:
+        import os
+        if not os.path.exists(svc_dir):
+            return
+        proc = await asyncio.create_subprocess_exec(
+            "svc", "-d", svc_dir,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=3.0)
+        _LOGGER.info(
+            "Stopped dbus-ble-sensors before bluetoothd restart"
+        )
+        await asyncio.sleep(0.5)
+    except Exception:
+        _LOGGER.debug(
+            "Could not stop dbus-ble-sensors (may not exist)",
+            exc_info=True,
+        )
+
+
+async def _start_raw_hci_scanner() -> None:
+    """Re-enable ``dbus-ble-sensors`` if it exists."""
+    svc_dir = "/service/dbus-ble-sensors"
+    try:
+        import os
+        if not os.path.exists(svc_dir):
+            return
+        proc = await asyncio.create_subprocess_exec(
+            "svc", "-u", svc_dir,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=3.0)
+        _LOGGER.info("Re-enabled dbus-ble-sensors after bluetoothd restart")
+    except Exception:
+        _LOGGER.debug(
+            "Could not re-enable dbus-ble-sensors",
+            exc_info=True,
+        )
+
+
+async def close_bus() -> None:
+    """Disconnect the shared bus if it's open.
+
+    Safe to call even if no bus was ever created.
+    """
+    global _bus, _bus_loop
+    if _bus is not None:
+        try:
+            _bus.disconnect()
+        except Exception:
+            pass
+        _bus = None
+        _bus_loop = None

--- a/dbus-serialbattery/ext/bleak_connection_manager/diagnostics.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/diagnostics.py
@@ -1,0 +1,393 @@
+"""Stuck-state diagnosis and targeted recovery for BLE connections.
+
+Provides :func:`diagnose_stuck_state` to determine why a BLE connection
+is stuck, and :func:`clear_stuck_state` to apply the minimal targeted
+fix for each diagnosis.
+
+Diagnosis uses two layers:
+
+1. **D-Bus** (via ``bluez`` module) — BlueZ's cached view of the world.
+2. **HCI** (via ``hci`` module) — the kernel's ground-truth connection
+   list, queried through ``hcitool``.
+
+Cross-referencing these two layers is the only reliable way to detect
+phantom connections and stale handles.  If ``hcitool`` is not available,
+HCI-dependent diagnostics (phantom detection, orphan handle detection)
+are skipped and the module trusts D-Bus alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+from enum import Enum
+from pathlib import Path
+
+from .bluez import _get_device_properties, disconnect_device, remove_device
+from .const import IS_LINUX
+from .hci import disconnect_by_address, find_connection_by_address, hci_available
+
+_LOGGER = logging.getLogger(__name__)
+
+_BLUEZ_LIB_PATHS = [
+    Path("/data/var/lib/bluetooth"),  # Venus OS
+    Path("/var/lib/bluetooth"),       # Standard Linux
+]
+
+
+def _find_bluez_lib() -> Path | None:
+    """Find the BlueZ persistent storage directory."""
+    for p in _BLUEZ_LIB_PATHS:
+        if p.is_dir():
+            return p
+    return None
+
+
+async def _delete_bluez_cache(address: str, adapter: str = "hci0") -> bool:
+    """Delete the BlueZ persistent cache for a device, bypassing D-Bus.
+
+    When ``RemoveDevice`` hangs (phantom connections where BlueZ
+    internally tries to ``Disconnect()`` first), this function removes
+    the on-disk device directory that BlueZ persists GATT attributes
+    and connection info in.  After deletion, ``hciconfig down/up`` is
+    used to force BlueZ to drop the in-memory phantom state.
+
+    This is a last-resort cleanup path for phantom connections.
+    """
+    if not IS_LINUX:
+        return False
+
+    bluez_lib = _find_bluez_lib()
+    if bluez_lib is None:
+        _LOGGER.debug("BlueZ lib directory not found")
+        return False
+
+    # Resolve adapter BD_ADDR from hciconfig
+    hciconfig = shutil.which("hciconfig")
+    if hciconfig is None:
+        _LOGGER.debug("hciconfig not found, cannot delete BlueZ cache")
+        return False
+
+    try:
+        result = await asyncio.to_thread(
+            subprocess.run,
+            [hciconfig, adapter],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        adapter_addr: str | None = None
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("BD Address:"):
+                adapter_addr = line.split()[2].strip()
+                break
+        if not adapter_addr:
+            _LOGGER.debug("Could not determine BD address for %s", adapter)
+            return False
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+    # Build path using colons (BlueZ uses colons in directory names)
+    dev_addr = address.upper()
+    device_dir = bluez_lib / adapter_addr / dev_addr
+
+    if not device_dir.is_dir():
+        # Also check the cache subdirectory
+        cache_entry = bluez_lib / adapter_addr / "cache" / dev_addr
+        if cache_entry.is_file():
+            try:
+                cache_entry.unlink()
+                _LOGGER.info(
+                    "%s: Deleted BlueZ cache entry %s", address, cache_entry,
+                )
+            except OSError as exc:
+                _LOGGER.debug(
+                    "%s: Could not delete cache entry: %s", address, exc,
+                )
+        else:
+            _LOGGER.debug(
+                "%s: No BlueZ device dir at %s", address, device_dir,
+            )
+            # No on-disk state to delete — still try power-cycle to
+            # clear the in-memory phantom.
+
+    else:
+        try:
+            shutil.rmtree(device_dir)
+            _LOGGER.info(
+                "%s: Deleted BlueZ device dir %s", address, device_dir,
+            )
+        except OSError as exc:
+            _LOGGER.warning(
+                "%s: Failed to delete BlueZ device dir: %s", address, exc,
+            )
+            return False
+
+    # Force BlueZ to re-read by power-cycling the specific adapter.
+    # When the adapter goes down, BlueZ drops all device objects for it.
+    # When it comes back up, BlueZ re-reads the storage — but the
+    # phantom's directory is gone, so it won't be reloaded.
+    try:
+        await asyncio.to_thread(
+            subprocess.run,
+            [hciconfig, adapter, "down"],
+            capture_output=True,
+            timeout=5.0,
+        )
+        await asyncio.sleep(0.5)
+        await asyncio.to_thread(
+            subprocess.run,
+            [hciconfig, adapter, "up"],
+            capture_output=True,
+            timeout=5.0,
+        )
+        _LOGGER.info(
+            "%s: Power-cycled %s to clear phantom from BlueZ",
+            address,
+            adapter,
+        )
+        # Wait for BlueZ to fully re-initialize the adapter.  The
+        # adapter goes through power-off → power-on → ready, which
+        # takes several seconds on real hardware.
+        await asyncio.sleep(5.0)
+    except (OSError, subprocess.TimeoutExpired):
+        _LOGGER.debug("%s: hciconfig down/up failed for %s", address, adapter)
+
+    return True
+
+
+class StuckState(Enum):
+    """Diagnosis of why a BLE connection is stuck.
+
+    Each value maps to a specific recovery action in
+    :func:`clear_stuck_state`.
+    """
+
+    NOT_STUCK = "not_stuck"
+    INACTIVE_CONNECTION = "inactive_connection"
+    STALE_CACHE = "stale_cache"
+    ORPHAN_HCI_HANDLE = "orphan_hci_handle"
+    PHANTOM_NO_HANDLE = "phantom_no_handle"
+
+
+async def diagnose_stuck_state(
+    address: str,
+    adapter: str,
+    adapters: list[str] | None = None,
+) -> StuckState:
+    """Determine what kind of stuck state a device is in.
+
+    Cross-references D-Bus properties with HCI connection state:
+
+    - **PHANTOM_NO_HANDLE**: D-Bus ``Connected=True`` but no HCI handle
+      exists on any adapter.  This is the classic phantom — BlueZ
+      believes the device is connected but there is no radio link.
+      (Stuck State 1)
+    - **INACTIVE_CONNECTION**: D-Bus ``Connected=True``,
+      ``ServicesResolved`` is not ``True``, and an HCI handle exists.
+      The radio link is up but GATT never resolved — dead handle.
+      (Stuck State 2)
+    - **ORPHAN_HCI_HANDLE**: D-Bus does NOT show the device as connected,
+      but an HCI handle exists.  The service that created the connection
+      died without cleaning up, and the peripheral is stuck in connected
+      mode (won't advertise).  (Stuck State 20)
+    - **STALE_CACHE**: Device exists on D-Bus but is not connected and
+      has no HCI handle.  Stale BlueZ cache that may cause
+      ``InProgress`` errors.  (Stuck State 13)
+    - **NOT_STUCK**: Device appears healthy or is not present.
+
+    Parameters
+    ----------
+    address:
+        The BLE device MAC address.
+    adapter:
+        The primary adapter name (e.g. ``"hci0"``).
+    adapters:
+        All available adapters.  If provided, HCI connections are
+        checked across all of them.  If ``None``, only *adapter* is
+        checked.
+    """
+    if not IS_LINUX:
+        return StuckState.NOT_STUCK
+
+    # Layer 1: Check HCI (ground truth)
+    # If HCI is not functional on this platform (e.g. "bind(): bad family"
+    # on some kernels), we cannot cross-reference D-Bus with HCI, so we
+    # must not diagnose phantom/orphan states — they would be false
+    # positives that remove devices BlueZ is actively connecting to.
+    search_adapters = adapters if adapters else [adapter]
+    # hcitool subprocess calls block for up to 5 s each — keep them off
+    # the event loop thread or every other connection in this process
+    # stalls while we diagnose.
+    _hci_works = await asyncio.to_thread(
+        lambda: any(hci_available(a) for a in search_adapters)
+    )
+
+    hci_conn = None
+    if _hci_works:
+        hci_conn = await asyncio.to_thread(
+            find_connection_by_address, address, adapters=search_adapters
+        )
+
+    # Layer 2: Check D-Bus (BlueZ's cached view)
+    props = await _get_device_properties(address, adapter)
+
+    dbus_connected = False
+    dbus_exists = props is not None
+    if props is not None:
+        dbus_connected = props.get("Connected", False)
+
+    # Cross-reference the two layers
+    if dbus_connected:
+        if not _hci_works:
+            # HCI unavailable — we cannot tell phantom from real.
+            # Trust D-Bus and assume the connection is healthy.
+            _LOGGER.debug(
+                "%s: D-Bus Connected=True, HCI unavailable — "
+                "skipping phantom detection",
+                address,
+            )
+            return StuckState.NOT_STUCK
+
+        services_resolved = props.get("ServicesResolved", False)  # type: ignore[union-attr]
+        if hci_conn is None:
+            # D-Bus says connected, HCI says no handle → PHANTOM.
+            # This is true regardless of ServicesResolved — BlueZ can
+            # cache both Connected=True and ServicesResolved=True from
+            # a previous session even after the radio link is dead.
+            return StuckState.PHANTOM_NO_HANDLE
+        if services_resolved is not True:
+            # D-Bus connected + HCI handle exists + GATT not resolved
+            return StuckState.INACTIVE_CONNECTION
+        # Both layers agree: connected with services resolved → healthy
+        return StuckState.NOT_STUCK
+
+    # D-Bus does NOT show connected
+    if _hci_works and hci_conn is not None:
+        # D-Bus says not connected (or not present), but HCI handle
+        # exists → orphan handle from a crashed service.  The peripheral
+        # is stuck in connected mode and won't advertise.
+        return StuckState.ORPHAN_HCI_HANDLE
+
+    if dbus_exists:
+        # Device in D-Bus cache but not connected, no HCI handle
+        return StuckState.STALE_CACHE
+
+    # Not in D-Bus, no HCI handle → clean state
+    return StuckState.NOT_STUCK
+
+
+async def clear_stuck_state(
+    address: str,
+    adapter: str,
+    state: StuckState,
+    adapters: list[str] | None = None,
+) -> bool:
+    """Apply the targeted fix for a diagnosed stuck state.
+
+    - **PHANTOM_NO_HANDLE**: Disconnect + remove via D-Bus (clears the
+      stale BlueZ state since there's no HCI handle to clear).
+    - **INACTIVE_CONNECTION**: Disconnect via D-Bus (which sends HCI
+      Disconnect since a handle exists), then remove.
+    - **ORPHAN_HCI_HANDLE**: Disconnect at the HCI level to free the
+      peripheral, then remove from D-Bus.  This is the fix for
+      Stuck State 20 -- D-Bus ``RemoveDevice`` alone does NOT clear
+      HCI handles.
+    - **STALE_CACHE**: Remove the device from BlueZ cache.
+
+    Returns ``True`` if the cleanup action was executed.
+    """
+    if state == StuckState.NOT_STUCK:
+        return True
+
+    if not IS_LINUX:
+        return False
+
+    if state == StuckState.PHANTOM_NO_HANDLE:
+        _LOGGER.info(
+            "%s: Clearing phantom connection (D-Bus Connected=True "
+            "but no HCI handle)",
+            address,
+        )
+        # Skip disconnect_device — there is no real HCI link, so BlueZ's
+        # Disconnect() will block indefinitely waiting for a link teardown
+        # that can never happen.
+        #
+        # Strategy: Try RemoveDevice with a short timeout.  If that also
+        # hangs (BlueZ internally calls Disconnect before Remove for
+        # "Connected" devices), fall back to deleting the BlueZ persistent
+        # cache directory for this device.  The device will be re-discovered
+        # on the next scan as if new.
+        cleared = False
+        try:
+            cleared = await asyncio.wait_for(
+                remove_device(address, adapter), timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.debug(
+                "%s: remove_device timed out (expected for phantom)",
+                address,
+            )
+
+        if not cleared:
+            cleared = await _delete_bluez_cache(address, adapter)
+
+        if cleared:
+            _LOGGER.info("%s: Phantom cleared successfully", address)
+        else:
+            _LOGGER.warning(
+                "%s: Could not clear phantom — scan may fail",
+                address,
+            )
+        return True
+
+    if state == StuckState.INACTIVE_CONNECTION:
+        _LOGGER.info(
+            "%s: Clearing inactive connection (Connected but "
+            "ServicesResolved is not True)",
+            address,
+        )
+        try:
+            await asyncio.wait_for(
+                disconnect_device(address, adapter), timeout=10.0,
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.warning(
+                "%s: disconnect_device timed out after 10 s", address,
+            )
+        try:
+            await asyncio.wait_for(
+                remove_device(address, adapter), timeout=10.0,
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.warning(
+                "%s: remove_device timed out after 10 s", address,
+            )
+        return True
+
+    if state == StuckState.ORPHAN_HCI_HANDLE:
+        _LOGGER.info(
+            "%s: Clearing orphan HCI handle (peripheral stuck in "
+            "connected mode, won't advertise)",
+            address,
+        )
+        search_adapters = adapters if adapters else [adapter]
+        await asyncio.to_thread(
+            disconnect_by_address, address, adapters=search_adapters
+        )
+        await remove_device(address, adapter)
+        return True
+
+    if state == StuckState.STALE_CACHE:
+        _LOGGER.info(
+            "%s: Removing stale BlueZ cache entry on %s",
+            address,
+            adapter,
+        )
+        await remove_device(address, adapter)
+        return True
+
+    return False

--- a/dbus-serialbattery/ext/bleak_connection_manager/hci.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/hci.py
@@ -1,0 +1,373 @@
+"""HCI connection inspection and control via ``hcitool``.
+
+Provides ground-truth BLE connection state by querying the Linux HCI
+layer through the ``hcitool`` command-line utility (part of BlueZ).
+This fills a critical gap: D-Bus (BlueZ layer 2) can disagree with
+HCI (layer 1), and detecting that mismatch is the only way to find
+phantom connections and stale handles.
+
+At import time the module probes for ``hcitool`` on ``$PATH``.  If it
+is not found, all functions gracefully degrade — returning empty results
+or ``False`` — and phantom/orphan detection in the diagnostics module
+is skipped.
+
+Key functions:
+
+- :func:`get_connections` — list active HCI connections on an adapter
+  (equivalent to ``hcitool con``).
+- :func:`disconnect_handle` — disconnect a specific HCI handle
+  (equivalent to ``hcitool ledc <handle>``).
+- :func:`cancel_le_connect` — cancel a pending LE Create Connection
+  (equivalent to ``hcitool cmd 0x08 0x000E``).
+- :func:`find_connection_by_address` — find a connection by BLE MAC.
+- :func:`hci_available` — check if ``hcitool`` is present and usable.
+
+**Requires Linux and ``hcitool`` on PATH** (typically from the
+``bluez`` package).  All functions degrade gracefully when these
+conditions are not met.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+from .const import IS_LINUX
+
+_LOGGER = logging.getLogger(__name__)
+
+# ── hcitool availability probe ─────────────────────────────────────
+
+_HCITOOL: str | None = shutil.which("hcitool") if IS_LINUX else None
+
+if IS_LINUX and _HCITOOL is None:
+    _LOGGER.debug("hcitool not found on PATH; HCI diagnostics disabled")
+
+
+# ── HCI disconnect reason codes ───────────────────────────────────
+# From Bluetooth Core Spec Vol 1 Part F (Error Codes).
+
+HCI_DISCONNECT_REASONS: dict[int, str] = {
+    0x05: "Authentication Failure",
+    0x06: "PIN or Key Missing",
+    0x07: "Memory Capacity Exceeded",
+    0x08: "Connection Timeout",
+    0x09: "Connection Limit Exceeded",
+    0x0A: "Synchronous Connection Limit Exceeded",
+    0x0C: "Command Disallowed",
+    0x0D: "Rejected Limited Resources",
+    0x0E: "Rejected Security Reasons",
+    0x0F: "Rejected Unacceptable BD_ADDR",
+    0x10: "Connection Accept Timeout Exceeded",
+    0x13: "Remote User Terminated Connection",
+    0x14: "Remote Device Terminated Low Resources",
+    0x15: "Remote Device Terminated Power Off",
+    0x16: "Connection Terminated by Local Host",
+    0x1A: "Unsupported Remote Feature",
+    0x1F: "Unspecified Error",
+    0x22: "LMP/LL Response Timeout",
+    0x28: "Instant Passed",
+    0x2A: "Different Transaction Collision",
+    0x3B: "Unacceptable Connection Parameters",
+    0x3E: "Connection Failed to be Established",
+}
+
+
+def disconnect_reason_str(reason: int) -> str:
+    """Return a human-readable string for an HCI disconnect reason code."""
+    name = HCI_DISCONNECT_REASONS.get(reason)
+    if name:
+        return f"{name} (0x{reason:02X})"
+    return f"Unknown (0x{reason:02X})"
+
+
+# ── Public data model ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HciConnection:
+    """A single active HCI connection on an adapter.
+
+    Attributes
+    ----------
+    handle:
+        The HCI connection handle (1-4095).
+    address:
+        The remote device's Bluetooth address (e.g. ``"AA:BB:CC:DD:EE:FF"``).
+    link_type:
+        The link type (``0x80`` for LE, ``0x01`` for ACL, etc.).
+    link_type_name:
+        Human-readable link type (``"LE"``, ``"ACL"``, etc.).
+    outgoing:
+        ``True`` if this host initiated the connection (central role).
+    state:
+        HCI connection state code.
+    link_mode:
+        HCI link mode flags (0 when unavailable).
+    adapter:
+        The adapter name (e.g. ``"hci0"``).
+    """
+
+    handle: int
+    address: str
+    link_type: int
+    link_type_name: str
+    outgoing: bool
+    state: int
+    link_mode: int
+    adapter: str
+
+
+# ── hcitool output parsing ─────────────────────────────────────────
+
+# Example output of `hcitool -i hci0 con`:
+#   Connections:
+#   	< LE AA:BB:CC:DD:EE:FF handle 64 state 1 lm MASTER
+#   	> ACL 11:22:33:44:55:66 handle 42 state 1 lm SLAVE
+#
+# Fields: direction(</>)  type  address  "handle"  N  "state"  N  "lm"  mode
+
+_CON_RE = re.compile(
+    r"^\s*([<>])\s+"                  # direction
+    r"(\w+)\s+"                       # link type (LE, ACL, SCO, eSCO)
+    r"([0-9A-Fa-f:]{17})\s+"         # BD_ADDR
+    r"handle\s+(\d+)\s+"             # handle
+    r"state\s+(\d+)"                  # state
+    r"(?:\s+lm\s+(\S+))?",           # link mode (optional)
+    re.MULTILINE,
+)
+
+_LINK_TYPE_MAP: dict[str, int] = {
+    "LE": 0x80,
+    "ACL": 0x01,
+    "SCO": 0x00,
+    "eSCO": 0x02,
+}
+
+
+def _parse_hcitool_con(output: str, adapter: str) -> list[HciConnection]:
+    """Parse the output of ``hcitool con`` into HciConnection objects."""
+    connections: list[HciConnection] = []
+    for m in _CON_RE.finditer(output):
+        direction, link_name, address, handle_s, state_s, lm = m.groups()
+        link_type = _LINK_TYPE_MAP.get(link_name, 0xFF)
+        connections.append(
+            HciConnection(
+                handle=int(handle_s),
+                address=address.upper(),
+                link_type=link_type,
+                link_type_name=link_name,
+                outgoing=(direction == "<"),
+                state=int(state_s),
+                link_mode=0,
+                adapter=adapter,
+            )
+        )
+    return connections
+
+
+# ── Core functions ─────────────────────────────────────────────────
+
+
+def hci_available(adapter: str = "hci0") -> bool:
+    """Test whether ``hcitool`` is usable for HCI queries.
+
+    Returns ``True`` if ``hcitool`` is on PATH and can query the
+    given adapter.  A ``False`` result means :func:`get_connections`
+    will always return ``[]``, so callers should not rely on HCI for
+    diagnostics.
+    """
+    if _HCITOOL is None:
+        return False
+    try:
+        result = subprocess.run(
+            [_HCITOOL, "-i", adapter, "con"],
+            capture_output=True,
+            timeout=5.0,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def get_connections(adapter: str = "hci0") -> list[HciConnection]:
+    """List active HCI connections on an adapter.
+
+    Equivalent to ``hcitool -i <adapter> con``.
+
+    Returns a list of :class:`HciConnection` objects, or an empty list
+    if ``hcitool`` is not available or the query fails.
+    """
+    if _HCITOOL is None:
+        return []
+
+    try:
+        result = subprocess.run(
+            [_HCITOOL, "-i", adapter, "con"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if result.returncode != 0:
+            _LOGGER.debug(
+                "hcitool con failed on %s: %s",
+                adapter,
+                result.stderr.strip(),
+            )
+            return []
+        return _parse_hcitool_con(result.stdout, adapter)
+    except subprocess.TimeoutExpired:
+        _LOGGER.debug("hcitool con timed out on %s", adapter)
+        return []
+    except OSError as ex:
+        _LOGGER.debug("hcitool con failed on %s: %s", adapter, ex)
+        return []
+
+
+def find_connection_by_address(
+    address: str,
+    adapter: str | None = None,
+    adapters: list[str] | None = None,
+) -> HciConnection | None:
+    """Find an active HCI connection by BLE MAC address.
+
+    Searches the specified adapter(s) for a connection matching the
+    given address.
+
+    Parameters
+    ----------
+    address:
+        The BLE MAC address to search for (case-insensitive).
+    adapter:
+        A single adapter to check.
+    adapters:
+        Multiple adapters to check.
+
+    Returns the matching :class:`HciConnection`, or ``None`` if not
+    found.
+    """
+    target = address.upper()
+
+    if adapter is not None:
+        search_adapters = [adapter]
+    elif adapters is not None:
+        search_adapters = adapters
+    else:
+        search_adapters = ["hci0"]
+
+    for adap in search_adapters:
+        for conn in get_connections(adap):
+            if conn.address.upper() == target:
+                return conn
+
+    return None
+
+
+def disconnect_handle(
+    adapter: str,
+    handle: int,
+    reason: int = 0x13,
+) -> bool:
+    """Disconnect a specific HCI connection handle.
+
+    Equivalent to ``hcitool -i <adapter> ledc <handle>``.
+
+    Returns ``True`` if the command was sent successfully.
+    """
+    if _HCITOOL is None:
+        return False
+
+    try:
+        result = subprocess.run(
+            [_HCITOOL, "-i", adapter, "ledc", str(handle)],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if result.returncode == 0:
+            _LOGGER.info(
+                "Sent HCI disconnect for handle %d on %s", handle, adapter,
+            )
+            return True
+        _LOGGER.debug(
+            "hcitool ledc failed on %s handle %d: %s",
+            adapter,
+            handle,
+            result.stderr.strip(),
+        )
+        return False
+    except (OSError, subprocess.TimeoutExpired) as ex:
+        _LOGGER.debug(
+            "hcitool ledc failed on %s handle %d: %s", adapter, handle, ex,
+        )
+        return False
+
+
+def cancel_le_connect(adapter: str = "hci0") -> bool:
+    """Cancel a pending LE Create Connection on an adapter.
+
+    Equivalent to ``hcitool -i <adapter> cmd 0x08 0x000E``
+    (HCI LE Create Connection Cancel).
+
+    Safe to call even if no connection is pending — the controller
+    returns ``Command Disallowed`` which we silently ignore.
+
+    Returns ``True`` if the command was sent successfully.
+    """
+    if _HCITOOL is None:
+        return False
+
+    try:
+        result = subprocess.run(
+            [_HCITOOL, "-i", adapter, "cmd", "0x08", "0x000E"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if result.returncode == 0:
+            _LOGGER.info("Sent LE Create Connection Cancel on %s", adapter)
+            return True
+        _LOGGER.debug(
+            "hcitool cmd cancel failed on %s: %s",
+            adapter,
+            result.stderr.strip(),
+        )
+        return False
+    except (OSError, subprocess.TimeoutExpired) as ex:
+        _LOGGER.debug(
+            "hcitool cmd cancel failed on %s: %s", adapter, ex,
+        )
+        return False
+
+
+def disconnect_by_address(
+    address: str,
+    adapter: str | None = None,
+    adapters: list[str] | None = None,
+) -> bool:
+    """Find and disconnect an HCI connection by BLE MAC address.
+
+    Combines :func:`find_connection_by_address` and
+    :func:`disconnect_handle` into a single call.
+
+    Returns ``True`` if a connection was found and the disconnect
+    command was sent, ``False`` otherwise.
+    """
+    conn = find_connection_by_address(
+        address, adapter=adapter, adapters=adapters,
+    )
+    if conn is None:
+        return False
+
+    _LOGGER.info(
+        "Found stale HCI connection for %s on %s (handle=%d, type=%s), "
+        "sending disconnect",
+        conn.address,
+        conn.adapter,
+        conn.handle,
+        conn.link_type_name,
+    )
+    return disconnect_handle(conn.adapter, conn.handle)

--- a/dbus-serialbattery/ext/bleak_connection_manager/lock.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/lock.py
@@ -1,0 +1,179 @@
+"""Cross-process slot-based file locking for BLE adapter serialization.
+
+On multi-service systems several processes may compete for the same BLE
+adapter, causing ``InProgress`` errors.  This module provides slot-based
+``fcntl.flock`` helpers that limit concurrent BLE operations per adapter
+without blocking the asyncio event loop.
+
+**How it works:**
+
+Each adapter gets *N* lock files (slot 0 … slot N-1).  To acquire a
+slot, we try ``flock(LOCK_NB)`` on each slot file in order.  The first
+one that succeeds grants us a slot.  If all slots are held, we sleep
+and retry until the timeout expires.
+
+**Why this can't deadlock:**
+
+- Every ``flock`` call is non-blocking (``LOCK_NB``).  If a slot isn't
+  free, we don't hold anything while waiting — we release, sleep, retry.
+- No two-resource dependency = no deadlock possible.
+- ``flock`` is kernel-managed: if a process crashes, the kernel
+  releases all its locks automatically.  No stale counters.
+
+**Backwards compatibility:**
+
+``max_slots=1`` gives strict one-at-a-time serialization identical to
+the original binary lock behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .const import LockConfig
+
+try:
+    import fcntl
+
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
+
+_LOGGER = logging.getLogger(__name__)
+
+_SLOT_RETRY_INTERVAL = 0.15
+
+
+async def acquire_slot(
+    lock_config: LockConfig,
+    adapter: str | None,
+) -> int | None:
+    """Acquire one of N exclusive slots for the given adapter.
+
+    Tries each slot file (0 … max_slots-1) with ``flock(LOCK_NB)``.
+    The first slot that can be locked is returned as an open file
+    descriptor.
+
+    If no slot is available within *lock_config.lock_timeout*, returns
+    ``None`` — the caller should proceed without a slot (graceful
+    degradation).
+
+    Parameters
+    ----------
+    lock_config:
+        Lock configuration including slot count and timeout.
+    adapter:
+        Adapter name (e.g. ``"hci0"``).  Used to derive lock paths.
+
+    Returns
+    -------
+    int | None
+        An open file descriptor holding the slot lock, or ``None``
+        if acquisition timed out or locking is unavailable.
+    """
+    if not _HAS_FCNTL or not lock_config.enabled:
+        return None
+
+    elapsed = 0.0
+
+    while True:
+        # Try each slot in order
+        for slot_idx in range(lock_config.max_slots):
+            slot_path = lock_config.path_for_slot(adapter, slot_idx)
+            try:
+                fd = os.open(slot_path, os.O_CREAT | os.O_RDWR, 0o666)
+            except OSError:
+                _LOGGER.debug(
+                    "Failed to open slot file %s, skipping",
+                    slot_path,
+                    exc_info=True,
+                )
+                continue
+
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                _LOGGER.debug(
+                    "Acquired BLE slot %d/%d for %s (%s)",
+                    slot_idx,
+                    lock_config.max_slots,
+                    adapter,
+                    slot_path,
+                )
+                return fd
+            except OSError:
+                # Slot is held by another process — close and try next
+                os.close(fd)
+
+        # All slots busy — wait and retry
+        elapsed += _SLOT_RETRY_INTERVAL
+        if elapsed >= lock_config.lock_timeout:
+            _LOGGER.warning(
+                "Timed out waiting for a BLE slot on %s after %.1f s "
+                "(%d slots all held) — proceeding without slot",
+                adapter,
+                elapsed,
+                lock_config.max_slots,
+            )
+            return None
+
+        await asyncio.sleep(_SLOT_RETRY_INTERVAL)
+
+
+def release_slot(fd: int | None) -> None:
+    """Release a previously acquired slot lock.
+
+    Safe to call with ``None`` (no-op).
+    """
+    if fd is None:
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    except OSError:
+        _LOGGER.debug("Failed to release BLE slot", exc_info=True)
+
+
+def probe_free_slots(lock_config: LockConfig, adapter: str | None) -> int:
+    """Count how many connection slots are currently free for *adapter*.
+
+    Tries each slot file with ``flock(LOCK_NB)``.  Slots that can be
+    locked are immediately unlocked and counted as free.  Slots held by
+    other processes are counted as busy.
+
+    This is a **non-blocking snapshot** — the counts may change by the
+    time the caller acts on them.  Use this for scoring / prioritization,
+    not for hard guarantees.
+
+    Returns the number of free slots (0 … max_slots).
+    """
+    if not _HAS_FCNTL or not lock_config.enabled:
+        return lock_config.max_slots  # assume all free when locking disabled
+
+    free = 0
+    for slot_idx in range(lock_config.max_slots):
+        slot_path = lock_config.path_for_slot(adapter, slot_idx)
+        try:
+            fd = os.open(slot_path, os.O_CREAT | os.O_RDWR, 0o666)
+        except OSError:
+            continue
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            # Got the lock — slot is free.  Release immediately.
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            free += 1
+        except OSError:
+            pass  # Slot held by another process
+        finally:
+            os.close(fd)
+
+    return free
+
+
+# Backwards-compatible aliases
+acquire_lock = acquire_slot
+release_lock = release_slot

--- a/dbus-serialbattery/ext/bleak_connection_manager/recovery.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/recovery.py
@@ -1,0 +1,453 @@
+"""Adapter recovery and escalation chain for BLE connection failures.
+
+Provides a configurable escalation policy that tracks consecutive
+failures per adapter and recommends increasingly aggressive recovery
+actions.  The policy respects caller configuration — it never suggests
+an action the caller has disabled.
+
+Escalation levels (least to most disruptive)::
+
+    1. RETRY          — simple backoff retry
+    2. DIAGNOSE       — diagnose stuck state + targeted fix
+    3. CLEAR_BLUEZ    — clear InProgress-dominant stale BlueZ state
+    4. ROTATE_ADAPTER — switch to a different adapter
+    5. RESET_ADAPTER  — power cycle adapter (disrupts ALL connections)
+
+Adapter reset delegates to ``bluetooth-auto-recovery`` which handles
+MGMT socket power cycle, USB reset, and rfkill — much more robust
+than a simple ``hciconfig down/up``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from enum import Enum
+
+from .const import IS_LINUX
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EscalationAction(str, Enum):
+    """Actions the escalation policy can recommend."""
+
+    RETRY = "retry"
+    DIAGNOSE = "diagnose"
+    CLEAR_BLUEZ = "clear_bluez"
+    ROTATE_ADAPTER = "rotate"
+    RESET_ADAPTER = "reset"
+
+
+# Ordered from least to most disruptive
+_LEVELS = list(EscalationAction)
+
+
+@dataclass
+class EscalationConfig:
+    """Configuration for the recovery escalation chain.
+
+    Each escalation level can be individually enabled or disabled.
+    Thresholds control when each level triggers.
+
+    Parameters
+    ----------
+    diagnose_and_fix:
+        Enable stuck-state diagnosis + targeted fix.
+    clear_bluez_on_inprogress_dominance:
+        Enable BlueZ state cleanup when ``InProgress`` errors dominate.
+    rotate_adapter:
+        Enable adapter rotation on failure.  Requires multiple adapters.
+    reset_adapter:
+        Enable adapter reset as last resort.  **WARNING:** disrupts ALL
+        connections on the adapter.  Default ``False``.
+    rotate_after:
+        Consecutive failures before rotating adapter.
+    clear_after:
+        Consecutive ``InProgress`` failures before BlueZ cleanup.
+    reset_after:
+        Consecutive failures before adapter reset.
+    reset_cooldown:
+        Minimum seconds between adapter resets.
+    max_escalation:
+        Hard ceiling on escalation level.
+    """
+
+    diagnose_and_fix: bool = True
+    clear_bluez_on_inprogress_dominance: bool = True
+    rotate_adapter: bool = True
+    reset_adapter: bool = False
+    rotate_after: int = 2
+    clear_after: int = 4
+    reset_after: int = 6
+    reset_cooldown: float = 300.0
+    max_escalation: EscalationAction = EscalationAction.RESET_ADAPTER
+
+
+# Pre-built profiles for common service types
+PROFILE_BATTERY = EscalationConfig(
+    reset_adapter=True,
+    reset_after=6,
+    reset_cooldown=300.0,
+)
+
+PROFILE_SENSOR = EscalationConfig(
+    reset_adapter=False,
+    max_escalation=EscalationAction.ROTATE_ADAPTER,
+)
+
+PROFILE_ON_DEMAND = EscalationConfig(
+    clear_bluez_on_inprogress_dominance=False,
+    reset_adapter=False,
+    rotate_after=1,
+    max_escalation=EscalationAction.ROTATE_ADAPTER,
+)
+
+
+class EscalationPolicy:
+    """Track consecutive failures per adapter and decide escalation level.
+
+    The policy respects the caller's :class:`EscalationConfig` — it will
+    never suggest an action the caller has disabled.
+
+    Example::
+
+        config = EscalationConfig(reset_adapter=False)
+        policy = EscalationPolicy(["hci0", "hci1"], config=config)
+
+        action = policy.on_failure("hci0")
+        # action will never be RESET_ADAPTER because config disabled it
+
+        policy.on_success("hci0")  # resets failure counter
+    """
+
+    def __init__(
+        self,
+        adapters: list[str],
+        config: EscalationConfig | None = None,
+    ) -> None:
+        self._config = config or EscalationConfig()
+        self._adapters = adapters
+        self._max_level_idx = _LEVELS.index(self._config.max_escalation)
+        self._failures: dict[str, int] = {a: 0 for a in adapters}
+        self._last_reset: dict[str, float] = {a: 0.0 for a in adapters}
+
+    @property
+    def config(self) -> EscalationConfig:
+        """Return the current escalation configuration."""
+        return self._config
+
+    def on_failure(self, adapter: str) -> EscalationAction:
+        """Record a failure and return the next escalation action.
+
+        The returned action will never exceed *max_escalation* or
+        suggest a disabled level.
+        """
+        self._failures[adapter] = self._failures.get(adapter, 0) + 1
+        count = self._failures[adapter]
+
+        if (
+            count >= self._config.reset_after
+            and self._is_level_enabled(EscalationAction.RESET_ADAPTER)
+            and self._can_reset(adapter)
+        ):
+            return EscalationAction.RESET_ADAPTER
+
+        if count >= self._config.clear_after and self._is_level_enabled(
+            EscalationAction.CLEAR_BLUEZ
+        ):
+            return EscalationAction.CLEAR_BLUEZ
+
+        if count >= self._config.rotate_after and self._is_level_enabled(
+            EscalationAction.ROTATE_ADAPTER
+        ):
+            return EscalationAction.ROTATE_ADAPTER
+
+        if count >= 1 and self._is_level_enabled(EscalationAction.DIAGNOSE):
+            return EscalationAction.DIAGNOSE
+
+        return EscalationAction.RETRY
+
+    def on_success(self, adapter: str) -> None:
+        """Record a success — resets the failure counter for *adapter*."""
+        self._failures[adapter] = 0
+
+    def failure_count(self, adapter: str) -> int:
+        """Return the current consecutive failure count for *adapter*.
+
+        Used by adapter scoring to penalize adapters with recent failures.
+        """
+        return self._failures.get(adapter, 0)
+
+    def record_reset(self, adapter: str) -> None:
+        """Record that an adapter reset was performed."""
+        self._last_reset[adapter] = time.monotonic()
+        self._failures[adapter] = 0
+
+    def _is_level_enabled(self, level: EscalationAction) -> bool:
+        """Check if a given escalation level is enabled in config."""
+        if _LEVELS.index(level) > self._max_level_idx:
+            return False
+        level_config_map = {
+            EscalationAction.DIAGNOSE: self._config.diagnose_and_fix,
+            EscalationAction.CLEAR_BLUEZ: (
+                self._config.clear_bluez_on_inprogress_dominance
+            ),
+            EscalationAction.ROTATE_ADAPTER: self._config.rotate_adapter,
+            EscalationAction.RESET_ADAPTER: self._config.reset_adapter,
+        }
+        return level_config_map.get(level, True)
+
+    def _can_reset(self, adapter: str) -> bool:
+        """Check if enough time has passed since the last reset."""
+        last = self._last_reset.get(adapter, 0.0)
+        return (time.monotonic() - last) >= self._config.reset_cooldown
+
+
+def is_bluetoothd_alive() -> bool:
+    """Check whether ``bluetoothd`` is running.
+
+    Scans ``/proc`` for a process whose ``comm`` is ``bluetoothd``.
+    This avoids shelling out to ``pidof`` or ``pgrep``.
+
+    Returns ``True`` if at least one ``bluetoothd`` process is found,
+    ``False`` if not found or if ``/proc`` is unavailable (non-Linux).
+    """
+    if not IS_LINUX:
+        return True  # assume OK on non-Linux
+
+    proc_dir = "/proc"
+    try:
+        for entry in os.listdir(proc_dir):
+            if not entry.isdigit():
+                continue
+            comm_path = os.path.join(proc_dir, entry, "comm")
+            if not os.path.exists(comm_path):
+                continue
+            try:
+                with open(comm_path) as f:
+                    name = f.read().strip()
+                if name == "bluetoothd":
+                    return True
+            except (OSError, PermissionError):
+                continue
+    except OSError:
+        _LOGGER.debug("Cannot read /proc to check bluetoothd status")
+
+    return False
+
+
+async def restart_bluetoothd(
+    init_script: str = "/etc/init.d/bluetooth",
+    timeout: float = 5.0,
+) -> bool:
+    """Restart ``bluetoothd`` via the init script if it is not running.
+
+    On Venus OS, ``bluetoothd`` is managed by ``/etc/init.d/bluetooth``
+    (a SysV init script) with no crash supervision.  If it segfaults or
+    is killed, it stays dead until someone manually starts it.
+
+    This function:
+
+    1. Checks ``is_bluetoothd_alive()`` — if already running, returns
+       ``True`` immediately (no-op).
+    2. Runs ``<init_script> start`` via subprocess.
+    3. Waits up to *timeout* seconds for it to complete.
+    4. Verifies ``bluetoothd`` is running with a second ``/proc`` check.
+
+    Returns ``True`` if ``bluetoothd`` is running when the function
+    returns (whether it was already running or freshly started).
+    """
+    if not IS_LINUX:
+        return True
+
+    if is_bluetoothd_alive():
+        return True
+
+    if not os.path.isfile(init_script):
+        _LOGGER.error(
+            "Cannot restart bluetoothd: init script %s not found",
+            init_script,
+        )
+        return False
+
+    _LOGGER.warning(
+        "bluetoothd is not running — attempting restart via %s",
+        init_script,
+    )
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            init_script, "start",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            _LOGGER.error(
+                "bluetoothd restart timed out after %.0fs", timeout,
+            )
+            return False
+
+        if proc.returncode != 0:
+            _LOGGER.error(
+                "bluetoothd restart failed (exit %d): %s",
+                proc.returncode,
+                (stderr or stdout or b"").decode(errors="replace").strip(),
+            )
+            return False
+
+        await asyncio.sleep(0.5)
+
+        if is_bluetoothd_alive():
+            _LOGGER.info("bluetoothd restarted successfully")
+            return True
+
+        _LOGGER.error(
+            "bluetoothd init script exited 0 but process not found in /proc"
+        )
+        return False
+
+    except Exception:
+        _LOGGER.exception("Failed to restart bluetoothd")
+        return False
+
+
+async def invalidate_dbus_state() -> None:
+    """Tear down and invalidate all cached D-Bus state after an adapter reset.
+
+    An adapter reset (MGMT power cycle) causes ``bluetoothd`` to rebuild
+    its D-Bus object tree.  Any in-process D-Bus state cached before the
+    reset becomes stale:
+
+    * **Bleak's BlueZManager** singleton caches device paths, adapter
+      paths, and GATT service maps from ``GetManagedObjects`` and D-Bus
+      signals.  After a reset, these paths no longer exist in BlueZ.
+      The manager's ``async_init()`` skips re-initialization because
+      ``self._bus.connected`` is still ``True``, so the stale cache
+      persists indefinitely.
+
+    * **BCM's shared bus** (``dbus_bus.py``) may have pending state
+      tied to the old adapter configuration.
+
+    This function forces both to tear down so they rebuild fresh state
+    on next use.
+    """
+    # 1. Invalidate BCM's own shared bus
+    from .dbus_bus import close_bus
+    await close_bus()
+    _LOGGER.debug("Closed BCM shared D-Bus bus")
+
+    # 2. Invalidate Bleak's BlueZManager singleton
+    try:
+        from bleak.backends.bluezdbus.manager import _global_instances
+    except ImportError:
+        _LOGGER.debug("Bleak bluezdbus manager not available, skipping")
+        return
+
+    loop = asyncio.get_running_loop()
+    manager = _global_instances.get(loop)
+    if manager is None:
+        _LOGGER.debug("No BlueZManager instance for current event loop")
+        return
+
+    bus = getattr(manager, "_bus", None)
+    if bus is not None:
+        try:
+            bus.disconnect()
+        except Exception:
+            pass
+        manager._bus = None
+        _LOGGER.info(
+            "Invalidated BlueZManager D-Bus bus — will rebuild on next use"
+        )
+    else:
+        _LOGGER.debug("BlueZManager has no active bus")
+
+
+async def reset_adapter(adapter: str, mac: str = "") -> bool:
+    """Reset a BLE adapter using bluetooth-auto-recovery.
+
+    Delegates to ``bluetooth_auto_recovery.recover_adapter()`` which
+    handles MGMT socket power cycle, USB reset, and rfkill unblock.
+    This is the same approach used by Home Assistant's habluetooth.
+
+    After the reset:
+
+    1. Verifies that ``bluetoothd`` is still alive (restarts it if
+       it crashed during the reset — "Stuck State 11").
+    2. Invalidates all cached D-Bus state (BlueZManager singleton and
+       BCM's shared bus) so that the next connection attempt rebuilds
+       from ``GetManagedObjects`` instead of using stale cached paths.
+
+    Parameters
+    ----------
+    adapter:
+        The adapter name (e.g. ``"hci0"``).
+    mac:
+        The adapter MAC address.  If empty, recovery proceeds with
+        a best-effort adapter lookup.
+
+    Returns ``True`` if the reset appeared successful and ``bluetoothd``
+    is still alive.
+    """
+    if not IS_LINUX:
+        return False
+
+    try:
+        from bluetooth_auto_recovery import recover_adapter as _recover
+
+        hci_num = int(adapter.removeprefix("hci"))
+        result = await _recover(hci_num, mac or "00:00:00:00:00:00")
+        if result:
+            _LOGGER.info(
+                "Adapter %s reset successfully via bluetooth-auto-recovery",
+                adapter,
+            )
+        else:
+            _LOGGER.warning("Adapter %s reset returned failure", adapter)
+            return False
+
+        # Brief settle time for bluetoothd to stabilize
+        await asyncio.sleep(1.0)
+
+        # Verify bluetoothd survived the reset (Stuck State 11)
+        if not is_bluetoothd_alive():
+            _LOGGER.warning(
+                "bluetoothd died after resetting %s (Stuck State 11) "
+                "— attempting auto-restart",
+                adapter,
+            )
+            if await restart_bluetoothd():
+                await invalidate_dbus_state()
+                return True
+            _LOGGER.critical(
+                "bluetoothd could not be restarted after resetting %s",
+                adapter,
+            )
+            return False
+
+        # Invalidate cached D-Bus state — the adapter reset caused
+        # bluetoothd to rebuild its object tree, so any cached device
+        # paths, adapter properties, or GATT maps are now stale.
+        await invalidate_dbus_state()
+
+        return True
+
+    except ImportError:
+        _LOGGER.warning(
+            "bluetooth-auto-recovery not installed, cannot reset %s",
+            adapter,
+        )
+        return False
+    except Exception:
+        _LOGGER.exception("Failed to reset adapter %s", adapter)
+        return False

--- a/dbus-serialbattery/ext/bleak_connection_manager/scan_lock.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/scan_lock.py
@@ -1,0 +1,154 @@
+"""Per-adapter scan serialization (in-process).
+
+**Premise correction (2026-08-09, verified on Venus OS v3.73 / BlueZ
+5.72):** this module originally implemented a cross-process
+``fcntl.flock`` lock on the premise that BlueZ allows only one
+``StartDiscovery`` per adapter and returns ``InProgress`` to every
+other *process*.  That premise is false on modern BlueZ (>= 5.50):
+discovery sessions are per-D-Bus-client and merged — a second
+process's ``StartDiscovery`` joins the running discovery and succeeds
+(verified live on the target Cerbo with two concurrent processes).
+
+The real ``InProgress`` hazard is *same-client*: two concurrent scans
+in one process share bleak's D-Bus connection, and the second
+``StartDiscovery`` from the same client fails with ``InProgress``
+(bleak 2.x does not refcount active scans).  That is an in-process
+problem, so this module now provides a per-adapter ``asyncio.Lock``.
+The old file locks also serialized scans *across* services that BlueZ
+would happily merge, adding latency for nothing.
+
+The public API is unchanged (``acquire_scan_lock`` /
+``release_scan_lock`` / ``ScanLock``); only the handle type changed
+from a file descriptor to the held ``asyncio.Lock``.
+
+**Graceful degradation:**
+
+If the lock cannot be acquired within the configured timeout, the
+caller proceeds without the lock so a wedged scan cannot deadlock the
+BLE subsystem; the worst case is a same-client ``InProgress`` the
+retry loop already handles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .const import ScanLockConfig
+
+_LOGGER = logging.getLogger(__name__)
+
+# Per-adapter locks, recreated if the event loop changes (asyncio
+# primitives are bound to the loop they were created on).
+_locks: dict[str, asyncio.Lock] = {}
+_locks_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_lock(adapter: str) -> asyncio.Lock:
+    global _locks, _locks_loop
+    loop = asyncio.get_running_loop()
+    if _locks_loop is not loop:
+        _locks = {}
+        _locks_loop = loop
+    lock = _locks.get(adapter)
+    if lock is None:
+        lock = asyncio.Lock()
+        _locks[adapter] = lock
+    return lock
+
+
+async def acquire_scan_lock(
+    config: ScanLockConfig,
+    adapter: str | None,
+) -> asyncio.Lock | None:
+    """Acquire the per-adapter scan lock.
+
+    Waits up to *config.lock_timeout* seconds.  A timeout of ``0``
+    is a non-blocking attempt.
+
+    Returns
+    -------
+    asyncio.Lock | None
+        The held lock (pass to :func:`release_scan_lock`), or ``None``
+        if locking is disabled or the lock could not be acquired in
+        time.
+    """
+    if not config.enabled:
+        return None
+
+    lock = _get_lock(adapter or "hci0")
+
+    if config.lock_timeout <= 0:
+        # Non-blocking attempt.  Lock.acquire() on an uncontended lock
+        # completes without yielding, so this cannot race in-loop.
+        if lock.locked():
+            return None
+        await lock.acquire()
+        return lock
+
+    try:
+        await asyncio.wait_for(lock.acquire(), timeout=config.lock_timeout)
+    except asyncio.TimeoutError:
+        _LOGGER.warning(
+            "Timed out waiting for scan lock on %s after %.1f s "
+            "— scan lock not acquired",
+            adapter,
+            config.lock_timeout,
+        )
+        return None
+    return lock
+
+
+def release_scan_lock(lock: asyncio.Lock | None) -> None:
+    """Release a previously acquired scan lock.
+
+    Safe to call with ``None`` (no-op).
+    """
+    if lock is None:
+        return
+    try:
+        lock.release()
+    except RuntimeError:
+        _LOGGER.debug("Scan lock already released", exc_info=True)
+
+
+class ScanLock:
+    """Async context manager for per-adapter scan locking.
+
+    Usage::
+
+        async with ScanLock(config, "hci0"):
+            device = await BleakScanner.find_device_by_address(addr, ...)
+
+    If the lock cannot be acquired, the context manager still enters
+    (graceful degradation) but logs a warning.
+
+    Parameters
+    ----------
+    config:
+        Scan lock configuration.
+    adapter:
+        Adapter name (e.g. ``"hci0"``).
+    """
+
+    __slots__ = ("_config", "_adapter", "_lock")
+
+    def __init__(self, config: ScanLockConfig, adapter: str | None = "hci0") -> None:
+        self._config = config
+        self._adapter = adapter
+        self._lock: asyncio.Lock | None = None
+
+    async def __aenter__(self) -> "ScanLock":
+        self._lock = await acquire_scan_lock(self._config, self._adapter)
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        release_scan_lock(self._lock)
+        self._lock = None
+
+    @property
+    def acquired(self) -> bool:
+        """Whether the scan lock is currently held."""
+        return self._lock is not None

--- a/dbus-serialbattery/ext/bleak_connection_manager/scanner.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/scanner.py
@@ -1,0 +1,1018 @@
+"""Managed BLE scanning with adapter rotation, locking, and InProgress retry.
+
+This is the scan counterpart to :mod:`bleak_connection_manager.connection`.
+It wraps ``BleakScanner`` with:
+
+- **Per-adapter scan lock** — in-process ``asyncio.Lock`` so only one
+  scan per adapter runs at a time within this process (bleak shares one
+  D-Bus client, and a same-client double ``StartDiscovery`` returns
+  ``InProgress``; cross-process scans are merged by BlueZ >= 5.50 and
+  need no coordination).
+- **Adapter rotation** — if the scan lock on the current adapter can't be
+  acquired quickly, or if BlueZ returns ``InProgress``, automatically
+  rotate to the next adapter.
+- **Hard timeout** — wraps every ``BleakScanner`` call in
+  ``asyncio.wait_for()`` to guard against Stuck State 16 (scanner hangs
+  ignoring its own timeout parameter).
+- **Retry with backoff** — transient scan failures get retried across
+  adapters before giving up.
+
+Each workaround is independently removable.  When upstream or BlueZ
+fixes the root cause, the corresponding code path can be deleted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+
+from .adapters import discover_adapters, pick_adapter
+from .bluez import (
+    _power_cycle_adapter_with_cooldown,
+    ensure_adapter_scan_ready,
+    ensure_adapters_up,
+    get_connected_devices,
+    try_stop_discovery,
+)
+from .const import IS_LINUX, AdapterScanState, ScanLockConfig
+from .diagnostics import StuckState, clear_stuck_state, diagnose_stuck_state
+from .scan_lock import acquire_scan_lock, release_scan_lock
+
+_LOGGER = logging.getLogger(__name__)
+
+# Time to wait after clearing a phantom connection to let the
+# peripheral's supervision timer expire and start advertising again.
+# The clear itself includes a power cycle with its own wait, so this
+# additional wait is just for the peripheral side.
+_PHANTOM_CLEAR_WAIT = 3.0
+
+# Extra seconds added to the BleakScanner timeout to form the hard
+# asyncio.wait_for timeout.  This gives BleakScanner a chance to
+# return normally before the hard timeout fires.
+_HARD_TIMEOUT_BUFFER = 5.0
+
+# How long to try acquiring the scan lock on a single adapter before
+# giving up and rotating.  Short — we'd rather try another adapter
+# than wait a long time for one.
+_LOCK_ATTEMPT_TIMEOUT = 2.0
+
+# Brief pause between retries on different adapters.
+_RETRY_BACKOFF = 0.25
+
+
+def _is_inprogress(exc: BaseException) -> bool:
+    """Check if an exception is an InProgress error."""
+    err_str = str(exc).lower()
+    return "inprogress" in err_str or "in progress" in err_str
+
+
+def _is_passive_scan(**scanner_kwargs: Any) -> bool:
+    """Check if the caller requested passive scanning.
+
+    Passive scanning uses BlueZ AdvertisementMonitor1 instead of
+    StartDiscovery, so it cannot cause InProgress contention and
+    does not need the scan lock or adapter health checks.
+    """
+    return str(scanner_kwargs.get("scanning_mode", "")).lower() == "passive"
+
+
+def _is_service_unknown(exc: BaseException) -> bool:
+    """Check if an exception is a D-Bus ServiceUnknown error (bluetoothd not running)."""
+    from .dbus_bus import is_service_unknown_error
+    return is_service_unknown_error(exc)
+
+
+async def _try_recover_adapter(
+    adapter: str,
+    effective_adapters: list[str],
+    reason: str,
+) -> None:
+    """Attempt non-destructive recovery of a stuck adapter.
+
+    Uses the tiered strategy:
+    - **Tier 1**: Try ``StopDiscovery`` from our bus (zero-cost).
+    - **Tier 2**: If other adapters exist, just log and let the
+      scan loop rotate.  Do NOT power-cycle.
+    - Power-cycling (Tier 3) is NOT done here — it is deferred
+      to ``_last_resort_power_cycle`` after all adapters are
+      exhausted.
+
+    Parameters
+    ----------
+    adapter:
+        The adapter that is stuck.
+    effective_adapters:
+        All available adapters (used to decide whether rotation
+        is possible).
+    reason:
+        Human-readable description of why recovery is needed
+        (for log messages).
+    """
+    if not IS_LINUX:
+        return
+
+    # Tier 1: try StopDiscovery
+    cleared = await try_stop_discovery(adapter)
+    if cleared:
+        return
+
+    # Tier 2: if we have other adapters, rotation handles it
+    if len(effective_adapters) > 1:
+        _LOGGER.info(
+            "%s: %s — will rotate to another adapter "
+            "(avoiding power-cycle to preserve connections)",
+            adapter,
+            reason,
+        )
+    else:
+        _LOGGER.warning(
+            "%s: %s — single adapter, no rotation possible",
+            adapter,
+            reason,
+        )
+
+
+async def _last_resort_power_cycle(
+    stuck_adapters: set[str],
+    effective_adapters: list[str],
+) -> str | None:
+    """Power-cycle the best candidate adapter as a last resort.
+
+    Called when all adapters are stuck and no scan can proceed.
+    Picks the adapter with the fewest active BLE connections to
+    minimize disruption.
+
+    Returns the adapter name that was power-cycled, or ``None``
+    if none could be cycled (cooldown, errors, etc.).
+    """
+    if not IS_LINUX or not stuck_adapters:
+        return None
+
+    # Score each stuck adapter: prefer the one with fewest connections
+    best_adapter: str | None = None
+    best_count: int | None = None
+
+    for adapter in effective_adapters:
+        if adapter not in stuck_adapters:
+            continue
+        connected = await get_connected_devices(adapter)
+        count = len(connected)
+        if best_count is None or count < best_count:
+            best_adapter = adapter
+            best_count = count
+
+    if best_adapter is None:
+        return None
+
+    _LOGGER.warning(
+        "All adapters stuck — power-cycling %s as last resort "
+        "(%d active connection(s))",
+        best_adapter,
+        best_count,
+    )
+    if await _power_cycle_adapter_with_cooldown(best_adapter):
+        return best_adapter
+    return None
+
+
+async def _diagnose_inprogress(adapter: str, address: str) -> None:
+    """Log BlueZ adapter state when InProgress occurs.
+
+    Queries the adapter's ``Discovering`` property and connected device
+    count via D-Bus to help identify *why* the adapter returned
+    InProgress.  Possible causes:
+
+    - ``Discovering: true`` — another process or a previous scan left
+      the adapter in discovery mode.
+    - ``Discovering: false`` — BlueZ has stale internal state from a
+      previous scan that was never properly cleaned up.
+    - Connected device count can reveal if the adapter is saturated.
+
+    This is diagnostic-only — it never modifies state.  Uses the shared
+    bus from :mod:`.dbus_bus` with raw ``bus.call()`` — no proxy objects,
+    no introspection, no fire-and-forget ``AddMatch``.
+    """
+    if not IS_LINUX:
+        return
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+
+        bus = await get_bus()
+        adapter_path = f"/org/bluez/{adapter}"
+
+        discovering_reply = await bus.call(
+            Message(
+                destination="org.bluez",
+                path=adapter_path,
+                interface="org.freedesktop.DBus.Properties",
+                member="Get",
+                signature="ss",
+                body=["org.bluez.Adapter1", "Discovering"],
+            )
+        )
+        powered_reply = await bus.call(
+            Message(
+                destination="org.bluez",
+                path=adapter_path,
+                interface="org.freedesktop.DBus.Properties",
+                member="Get",
+                signature="ss",
+                body=["org.bluez.Adapter1", "Powered"],
+            )
+        )
+
+        if (
+            discovering_reply.message_type == MessageType.ERROR
+            or powered_reply.message_type == MessageType.ERROR
+        ):
+            _LOGGER.debug(
+                "%s: D-Bus error querying adapter %s state",
+                address, adapter,
+            )
+            return
+
+        disc_val = discovering_reply.body[0]
+        if hasattr(disc_val, "value"):
+            disc_val = disc_val.value
+        pow_val = powered_reply.body[0]
+        if hasattr(pow_val, "value"):
+            pow_val = pow_val.value
+
+        _LOGGER.warning(
+            "%s: InProgress on %s — adapter state: "
+            "Powered=%s, Discovering=%s. "
+            "If Discovering=False, BlueZ has stale internal scan state "
+            "from a previous failed scan (likely our own code or vesmart). "
+            "If Discovering=True, another process holds a discovery session.",
+            address, adapter, pow_val, disc_val,
+        )
+    except Exception:
+        _LOGGER.debug(
+            "%s: Could not query %s adapter state for InProgress diagnosis",
+            address, adapter, exc_info=True,
+        )
+
+
+
+async def _find_in_bluez_cache(address: str) -> BLEDevice | None:
+    """Check if BlueZ already has a cached device entry from another scanner.
+
+    Uses the shared bus from :mod:`.dbus_bus` with raw ``bus.call()`` —
+    no proxy objects, no introspection, no fire-and-forget ``AddMatch``.
+    """
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return None
+
+    addr_path_suffix = address.upper().replace(":", "_")
+    bus = await get_bus()
+
+    reply = await bus.call(
+        Message(
+            destination="org.bluez",
+            path="/",
+            interface="org.freedesktop.DBus.ObjectManager",
+            member="GetManagedObjects",
+        )
+    )
+    if reply.message_type == MessageType.ERROR:
+        return None
+
+    objects = reply.body[0]
+    for path, interfaces in objects.items():
+        if not path.endswith(addr_path_suffix):
+            continue
+        dev_props = interfaces.get("org.bluez.Device1", {})
+        if not dev_props:
+            continue
+        dev_addr = dev_props.get("Address", {})
+        if hasattr(dev_addr, "value"):
+            dev_addr = dev_addr.value
+        dev_name = dev_props.get("Name", {})
+        if hasattr(dev_name, "value"):
+            dev_name = dev_name.value
+        dev_rssi = dev_props.get("RSSI", {})
+        if hasattr(dev_rssi, "value"):
+            dev_rssi = dev_rssi.value
+        if isinstance(dev_addr, str) and dev_addr.upper() == address.upper():
+            return BLEDevice(
+                address=dev_addr,
+                name=dev_name if isinstance(dev_name, str) else None,
+                rssi=dev_rssi if isinstance(dev_rssi, int) else 0,
+                details={"path": path},
+            )
+
+    return None
+
+
+async def _find_all_in_bluez_cache() -> list[BLEDevice]:
+    """Return all ``Device1`` entries from the BlueZ D-Bus cache.
+
+    Used as a fallback for ``discover()`` when an external raw HCI scan
+    is active — the scan continuously populates the cache via kernel
+    mgmt events, so the cache contents are reasonably fresh.
+    """
+    try:
+        from dbus_fast import Message, MessageType
+
+        from .dbus_bus import get_bus
+    except ImportError:
+        return []
+
+    bus = await get_bus()
+    reply = await bus.call(
+        Message(
+            destination="org.bluez",
+            path="/",
+            interface="org.freedesktop.DBus.ObjectManager",
+            member="GetManagedObjects",
+        )
+    )
+    if reply.message_type == MessageType.ERROR:
+        return []
+
+    devices: list[BLEDevice] = []
+    objects = reply.body[0]
+    for path, interfaces in objects.items():
+        dev_props = interfaces.get("org.bluez.Device1")
+        if dev_props is None:
+            continue
+        dev_addr = dev_props.get("Address")
+        if hasattr(dev_addr, "value"):
+            dev_addr = dev_addr.value
+        if not isinstance(dev_addr, str):
+            continue
+        dev_name = dev_props.get("Name")
+        if hasattr(dev_name, "value"):
+            dev_name = dev_name.value
+        dev_rssi = dev_props.get("RSSI")
+        if hasattr(dev_rssi, "value"):
+            dev_rssi = dev_rssi.value
+        devices.append(
+            BLEDevice(
+                address=dev_addr,
+                name=dev_name if isinstance(dev_name, str) else None,
+                rssi=dev_rssi if isinstance(dev_rssi, int) else 0,
+                details={"path": path},
+            )
+        )
+    return devices
+
+
+# How often to re-check the BlueZ cache while waiting for another
+# process's scan to populate it.
+_CACHE_POLL_INTERVAL = 0.5
+
+
+async def _poll_cache_while_locked(
+    address: str,
+    wait_seconds: float,
+) -> BLEDevice | None:
+    """Poll the BlueZ D-Bus cache while another scan holds the scan lock.
+
+    When the scan lock is busy, we know another process is running
+    ``StartDiscovery``.  Its results will appear in the shared BlueZ
+    D-Bus object tree.  Rather than wait for the lock and scan again
+    ourselves, we poll the cache — if the other process finds our
+    device, we can return it without ever scanning.
+
+    Returns the cached ``BLEDevice`` if found, or ``None`` after
+    *wait_seconds* expires.
+    """
+    elapsed = 0.0
+    while elapsed < wait_seconds:
+        await asyncio.sleep(_CACHE_POLL_INTERVAL)
+        elapsed += _CACHE_POLL_INTERVAL
+        try:
+            cached = await _find_in_bluez_cache(address)
+            if cached is not None:
+                return cached
+        except Exception:
+            pass  # Cache lookup failed — keep polling
+    return None
+
+
+async def find_device(
+    address: str,
+    *,
+    timeout: float = 10.0,
+    max_attempts: int = 3,
+    adapters: list[str] | None = None,
+    scan_lock_config: ScanLockConfig | None = None,
+    **scanner_kwargs: Any,
+) -> BLEDevice | None:
+    """Find a BLE device by address with cache-first strategy.
+
+    **Cache-first approach** (avoids ``StartDiscovery`` when possible):
+
+    1. Check the BlueZ D-Bus cache first.  If another process (or a
+       previous scan by this process) already discovered the device,
+       its ``Device1`` entry persists in BlueZ's object tree and we
+       return it immediately — **zero scanning overhead**.
+
+    2. If the cache misses, try to acquire the scan lock.  If the lock
+       is busy (another process is actively scanning), poll the cache
+       while waiting — that other process's scan results will appear
+       in the shared BlueZ cache.
+
+    3. Only if the cache remains empty *and* we hold the scan lock do
+       we actually call ``BleakScanner.find_device_by_address()``
+       (which triggers ``StartDiscovery``).
+
+    This eliminates the vast majority of ``StartDiscovery`` calls and
+    ``InProgress`` errors in multi-process environments.
+
+    Parameters
+    ----------
+    address:
+        The BLE device MAC address to find.
+    timeout:
+        Per-attempt scan timeout in seconds.  Each attempt on each
+        adapter gets this much time.
+    max_attempts:
+        Maximum total attempts across all adapters.
+    adapters:
+        List of adapters to rotate through.  If ``None``, auto-discovered.
+    scan_lock_config:
+        Cross-process scan lock configuration.  If ``None`` or
+        ``enabled=False``, no locking is performed.
+    **scanner_kwargs:
+        Additional keyword arguments passed to
+        ``BleakScanner.find_device_by_address()`` (e.g. ``scanning_mode``).
+
+    Returns
+    -------
+    BLEDevice | None
+        The found device, or ``None`` if not found after all attempts.
+    """
+    # Ensure BlueZ is available before any BLE operations.  On Venus OS
+    # our service may start before bluetoothd registers on D-Bus.
+    if IS_LINUX:
+        from .dbus_bus import wait_for_bluez
+        if not await wait_for_bluez():
+            _LOGGER.warning(
+                "%s: BlueZ not available — skipping scan",
+                address,
+            )
+            return None
+
+    if adapters is None and IS_LINUX:
+        adapters = discover_adapters()
+    effective_adapters = adapters or ["hci0"]
+
+    # ── Self-heal: bring up any adapters left DOWN ─────────────────
+    if IS_LINUX:
+        await ensure_adapters_up(effective_adapters)
+
+    # ── Step 1: Cache-first — check BlueZ D-Bus cache ─────────────
+    #
+    # If any process has previously scanned and found this device,
+    # BlueZ keeps a Device1 object in its cache.  We can return it
+    # directly without triggering StartDiscovery.
+    if IS_LINUX:
+        try:
+            cached = await _find_in_bluez_cache(address)
+            if cached is not None:
+                _LOGGER.debug(
+                    "%s: Found in BlueZ cache — scan avoided",
+                    address,
+                )
+                return cached
+        except Exception:
+            _LOGGER.debug(
+                "%s: BlueZ cache lookup failed, will scan",
+                address,
+                exc_info=True,
+            )
+
+    # ── Step 2: Pre-scan phantom check ─────────────────────────────
+    #
+    # If BlueZ has a stale "Connected" entry for this device but HCI
+    # shows no actual connection, clear it.  Without this, the
+    # peripheral thinks it's still connected and won't advertise,
+    # making all scan attempts fail.
+    if IS_LINUX:
+        try:
+            primary_adapter = effective_adapters[0]
+            state = await diagnose_stuck_state(
+                address, primary_adapter, adapters=effective_adapters,
+            )
+            if state in (
+                StuckState.PHANTOM_NO_HANDLE,
+                StuckState.INACTIVE_CONNECTION,
+                StuckState.ORPHAN_HCI_HANDLE,
+            ):
+                _LOGGER.info(
+                    "%s: Pre-scan detected %s, clearing before scan",
+                    address,
+                    state.value,
+                )
+                await clear_stuck_state(
+                    address, primary_adapter, state,
+                    adapters=effective_adapters,
+                )
+                # Give the peripheral time to notice the link is gone
+                # and start advertising again (supervision timeout).
+                await asyncio.sleep(_PHANTOM_CLEAR_WAIT)
+        except Exception:
+            _LOGGER.debug(
+                "%s: Pre-scan phantom check failed, proceeding",
+                address,
+                exc_info=True,
+            )
+
+    # ── Step 3: Scan with lock coordination ────────────────────────
+    #
+    # If the scan lock is busy, another scan in this process (or an
+    # external client's merged discovery) is running.  Poll
+    # the BlueZ cache while we wait — their scan results will show
+    # up in the shared cache.  Only scan ourselves if the cache
+    # stays empty and we acquire the lock.
+    #
+    # Passive scanning (AdvertisementMonitor1) does not call
+    # StartDiscovery, so it cannot cause InProgress contention.
+    # Skip the scan lock and adapter health check entirely.
+
+    passive = _is_passive_scan(**scanner_kwargs)
+    hard_timeout = timeout + _HARD_TIMEOUT_BUFFER
+    last_error: Exception | None = None
+    stuck_adapters: dict[str, AdapterScanState] = {}
+
+    for attempt in range(1, max_attempts + 1):
+        adapter = pick_adapter(effective_adapters, attempt)
+
+        # --- Try to acquire the scan lock for this adapter ---
+        fd: asyncio.Lock | None = None
+        if not passive and scan_lock_config is not None and scan_lock_config.enabled:
+            # Try non-blocking first (timeout=0)
+            instant_cfg = ScanLockConfig(
+                enabled=True,
+                lock_dir=scan_lock_config.lock_dir,
+                lock_template=scan_lock_config.lock_template,
+                lock_timeout=0.0,
+            )
+            fd = await acquire_scan_lock(instant_cfg, adapter)
+
+            if fd is None:
+                # Lock is busy — another scan in this process is
+                # running on this adapter.  Poll the BlueZ cache while
+                # waiting; its results appear in the shared cache.
+                _LOGGER.debug(
+                    "%s: Scan lock busy on %s, polling cache (attempt %d/%d)",
+                    address,
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                cached = await _poll_cache_while_locked(
+                    address, _LOCK_ATTEMPT_TIMEOUT,
+                )
+                if cached is not None:
+                    _LOGGER.debug(
+                        "%s: Found in cache while another scan ran",
+                        address,
+                    )
+                    return cached
+
+                # Cache still empty — try the lock one more time with
+                # a short timeout before rotating.
+                short_cfg = ScanLockConfig(
+                    enabled=True,
+                    lock_dir=scan_lock_config.lock_dir,
+                    lock_template=scan_lock_config.lock_template,
+                    lock_timeout=min(
+                        _LOCK_ATTEMPT_TIMEOUT,
+                        scan_lock_config.lock_timeout,
+                    ),
+                )
+                fd = await acquire_scan_lock(short_cfg, adapter)
+                if fd is None and len(effective_adapters) > 1:
+                    _LOGGER.debug(
+                        "%s: Scan lock still busy on %s, rotating",
+                        address,
+                        adapter,
+                    )
+                    continue
+
+        # ── Pre-scan adapter health check ──────────────────────────
+        if IS_LINUX and not passive:
+            try:
+                scan_state = await ensure_adapter_scan_ready(adapter)
+                if scan_state == AdapterScanState.EXTERNAL_SCAN:
+                    _LOGGER.info(
+                        "%s: External scan detected on %s, polling "
+                        "cache instead of scanning (attempt %d/%d)",
+                        address,
+                        adapter,
+                        attempt,
+                        max_attempts,
+                    )
+                    release_scan_lock(fd)
+                    fd = None
+                    cached = await _poll_cache_while_locked(
+                        address, timeout,
+                    )
+                    if cached is not None:
+                        _LOGGER.info(
+                            "%s: Found in cache via external scan on %s",
+                            address,
+                            adapter,
+                        )
+                        return cached
+                    continue
+                elif scan_state == AdapterScanState.STUCK:
+                    _LOGGER.warning(
+                        "%s: Adapter %s stuck (orphaned session), "
+                        "rotating (attempt %d/%d)",
+                        address,
+                        adapter,
+                        attempt,
+                        max_attempts,
+                    )
+                    stuck_adapters[adapter] = AdapterScanState.STUCK
+                    release_scan_lock(fd)
+                    fd = None
+                    continue
+            except Exception:
+                _LOGGER.debug(
+                    "%s: Pre-scan health check failed on %s, proceeding",
+                    address,
+                    adapter,
+                    exc_info=True,
+                )
+            except BaseException:
+                release_scan_lock(fd)
+                raise
+
+        try:
+            _LOGGER.debug(
+                "%s: Scanning on %s (attempt %d/%d, timeout=%.1f s)",
+                address,
+                adapter,
+                attempt,
+                max_attempts,
+                timeout,
+            )
+
+            kwargs: dict[str, Any] = dict(scanner_kwargs)
+            if IS_LINUX:
+                kwargs.setdefault("adapter", adapter)
+
+            device = await asyncio.wait_for(
+                BleakScanner.find_device_by_address(
+                    address,
+                    timeout=timeout,
+                    **kwargs,
+                ),
+                timeout=hard_timeout,
+            )
+
+            if device is not None:
+                _LOGGER.debug(
+                    "%s: Found on %s (attempt %d/%d)",
+                    address,
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                return device
+
+            _LOGGER.debug(
+                "%s: Not found on %s (attempt %d/%d)",
+                address,
+                adapter,
+                attempt,
+                max_attempts,
+            )
+
+        except (BleakError, asyncio.TimeoutError) as exc:
+            last_error = exc
+            if _is_inprogress(exc):
+                _LOGGER.warning(
+                    "%s: InProgress on %s, rotating (attempt %d/%d)",
+                    address,
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                await _diagnose_inprogress(adapter, address)
+                stuck_adapters[adapter] = AdapterScanState.STUCK
+                await _try_recover_adapter(
+                    adapter, effective_adapters,
+                    "InProgress during scan",
+                )
+            elif isinstance(exc, asyncio.TimeoutError):
+                _LOGGER.warning(
+                    "%s: Scanner hard timeout on %s after %.0f s "
+                    "(Stuck State 16), rotating (attempt %d/%d)",
+                    address,
+                    adapter,
+                    hard_timeout,
+                    attempt,
+                    max_attempts,
+                )
+                stuck_adapters[adapter] = AdapterScanState.STUCK
+                await _try_recover_adapter(
+                    adapter, effective_adapters,
+                    "hard timeout (Stuck State 16)",
+                )
+            elif IS_LINUX and _is_service_unknown(exc):
+                # bluetoothd died at runtime — clear the ready flag and
+                # wait for it to restart before the next attempt.
+                from .dbus_bus import mark_bluez_gone, wait_for_bluez
+                mark_bluez_gone()
+                _LOGGER.warning(
+                    "%s: org.bluez gone on %s (bluetoothd crashed?), "
+                    "waiting for restart (attempt %d/%d)",
+                    address,
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                await wait_for_bluez(timeout=30.0)
+            else:
+                _LOGGER.debug(
+                    "%s: Scan error on %s: %s (attempt %d/%d)",
+                    address,
+                    adapter,
+                    exc,
+                    attempt,
+                    max_attempts,
+                )
+
+        finally:
+            release_scan_lock(fd)
+
+        if attempt < max_attempts:
+            await asyncio.sleep(_RETRY_BACKOFF)
+
+    # ── Last resort: all attempts exhausted ────────────────────────
+    #
+    # Only power-cycle adapters that are STUCK (not EXTERNAL_SCAN —
+    # power-cycling is futile when an external raw HCI scanner will
+    # re-corrupt the state immediately).
+    truly_stuck = {
+        a for a, state in stuck_adapters.items()
+        if state == AdapterScanState.STUCK
+    }
+    if IS_LINUX and truly_stuck:
+        await _last_resort_power_cycle(truly_stuck, effective_adapters)
+
+    # Check BlueZ cache — another process's scan or the power-cycle
+    # may have populated it.
+    if IS_LINUX and last_error is not None and _is_inprogress(last_error):
+        _LOGGER.info(
+            "%s: All scans failed with InProgress, checking BlueZ cache",
+            address,
+        )
+        try:
+            cached = await _find_in_bluez_cache(address)
+            if cached is not None:
+                _LOGGER.info(
+                    "%s: Found in BlueZ cache (bypassed InProgress)",
+                    address,
+                )
+                return cached
+        except Exception:
+            _LOGGER.debug(
+                "%s: BlueZ cache lookup failed", address, exc_info=True,
+            )
+
+    if last_error is not None:
+        _LOGGER.warning(
+            "%s: All %d scan attempts failed, last error: %s",
+            address,
+            max_attempts,
+            last_error,
+        )
+    return None
+
+
+async def discover(
+    *,
+    timeout: float = 5.0,
+    max_attempts: int = 2,
+    adapters: list[str] | None = None,
+    scan_lock_config: ScanLockConfig | None = None,
+    **scanner_kwargs: Any,
+) -> list[BLEDevice]:
+    """Discover BLE devices with automatic adapter rotation.
+
+    Drop-in replacement for ``BleakScanner.discover()`` with scan lock,
+    adapter rotation, and InProgress retry built in.
+
+    Parameters
+    ----------
+    timeout:
+        Per-attempt scan duration in seconds.
+    max_attempts:
+        Maximum total attempts across all adapters.
+    adapters:
+        List of adapters to rotate through.  If ``None``, auto-discovered.
+    scan_lock_config:
+        Cross-process scan lock configuration.  If ``None`` or
+        ``enabled=False``, no locking is performed.
+    **scanner_kwargs:
+        Additional keyword arguments passed to
+        ``BleakScanner.discover()`` (e.g. ``scanning_mode``).
+
+    Returns
+    -------
+    list[BLEDevice]
+        List of discovered devices.  May be empty if all attempts fail.
+    """
+    # Ensure BlueZ is available before any BLE operations.
+    if IS_LINUX:
+        from .dbus_bus import wait_for_bluez
+        if not await wait_for_bluez():
+            _LOGGER.warning("BlueZ not available — skipping discover")
+            return []
+
+    if adapters is None and IS_LINUX:
+        adapters = discover_adapters()
+    effective_adapters = adapters or ["hci0"]
+
+    # Self-heal: bring up any adapters left DOWN.
+    if IS_LINUX:
+        await ensure_adapters_up(effective_adapters)
+
+    passive = _is_passive_scan(**scanner_kwargs)
+    hard_timeout = timeout + _HARD_TIMEOUT_BUFFER
+    stuck_adapters: dict[str, AdapterScanState] = {}
+
+    for attempt in range(1, max_attempts + 1):
+        adapter = pick_adapter(effective_adapters, attempt)
+
+        fd: asyncio.Lock | None = None
+        if not passive and scan_lock_config is not None and scan_lock_config.enabled:
+            lock_cfg_for_attempt = ScanLockConfig(
+                enabled=True,
+                lock_dir=scan_lock_config.lock_dir,
+                lock_template=scan_lock_config.lock_template,
+                lock_timeout=min(_LOCK_ATTEMPT_TIMEOUT, scan_lock_config.lock_timeout),
+            )
+            fd = await acquire_scan_lock(lock_cfg_for_attempt, adapter)
+            if fd is None and len(effective_adapters) > 1:
+                _LOGGER.debug(
+                    "Scan lock busy on %s, rotating (attempt %d/%d)",
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                continue
+
+        # Pre-scan adapter health check
+        if IS_LINUX and not passive:
+            try:
+                scan_state = await ensure_adapter_scan_ready(adapter)
+                if scan_state == AdapterScanState.EXTERNAL_SCAN:
+                    _LOGGER.info(
+                        "External scan detected on %s, returning "
+                        "cached devices (attempt %d/%d)",
+                        adapter,
+                        attempt,
+                        max_attempts,
+                    )
+                    release_scan_lock(fd)
+                    fd = None
+                    try:
+                        devices = await _find_all_in_bluez_cache()
+                        _LOGGER.info(
+                            "Returning %d devices from BlueZ cache "
+                            "(external scan on %s)",
+                            len(devices),
+                            adapter,
+                        )
+                        return devices
+                    except Exception:
+                        _LOGGER.debug(
+                            "Cache fallback failed on %s",
+                            adapter,
+                            exc_info=True,
+                        )
+                    continue
+                elif scan_state == AdapterScanState.STUCK:
+                    _LOGGER.warning(
+                        "Adapter %s stuck (orphaned session), "
+                        "rotating (attempt %d/%d)",
+                        adapter,
+                        attempt,
+                        max_attempts,
+                    )
+                    stuck_adapters[adapter] = AdapterScanState.STUCK
+                    release_scan_lock(fd)
+                    fd = None
+                    continue
+            except Exception:
+                _LOGGER.debug(
+                    "Pre-scan health check failed on %s, proceeding",
+                    adapter,
+                    exc_info=True,
+                )
+            except BaseException:
+                release_scan_lock(fd)
+                raise
+
+        try:
+            _LOGGER.debug(
+                "Discovering on %s (attempt %d/%d, timeout=%.1f s)",
+                adapter,
+                attempt,
+                max_attempts,
+                timeout,
+            )
+
+            kwargs: dict[str, Any] = dict(scanner_kwargs)
+            if IS_LINUX:
+                kwargs.setdefault("adapter", adapter)
+
+            devices = await asyncio.wait_for(
+                BleakScanner.discover(
+                    timeout=timeout,
+                    **kwargs,
+                ),
+                timeout=hard_timeout,
+            )
+
+            _LOGGER.debug(
+                "Discovered %d devices on %s (attempt %d/%d)",
+                len(devices),
+                adapter,
+                attempt,
+                max_attempts,
+            )
+            return list(devices)
+
+        except (BleakError, asyncio.TimeoutError) as exc:
+            if _is_inprogress(exc):
+                _LOGGER.warning(
+                    "InProgress on %s, rotating (attempt %d/%d)",
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                await _diagnose_inprogress(adapter, "discover")
+                stuck_adapters[adapter] = AdapterScanState.STUCK
+                await _try_recover_adapter(
+                    adapter, effective_adapters,
+                    "InProgress during discover",
+                )
+            elif isinstance(exc, asyncio.TimeoutError):
+                _LOGGER.warning(
+                    "Scanner hard timeout on %s after %.0f s "
+                    "(Stuck State 16), rotating (attempt %d/%d)",
+                    adapter,
+                    hard_timeout,
+                    attempt,
+                    max_attempts,
+                )
+                stuck_adapters[adapter] = AdapterScanState.STUCK
+                await _try_recover_adapter(
+                    adapter, effective_adapters,
+                    "hard timeout (Stuck State 16)",
+                )
+            elif IS_LINUX and _is_service_unknown(exc):
+                from .dbus_bus import mark_bluez_gone, wait_for_bluez
+                mark_bluez_gone()
+                _LOGGER.warning(
+                    "org.bluez gone on %s (bluetoothd crashed?), "
+                    "waiting for restart (attempt %d/%d)",
+                    adapter,
+                    attempt,
+                    max_attempts,
+                )
+                await wait_for_bluez(timeout=30.0)
+            else:
+                _LOGGER.debug(
+                    "Scan error on %s: %s (attempt %d/%d)",
+                    adapter,
+                    exc,
+                    attempt,
+                    max_attempts,
+                )
+
+        finally:
+            release_scan_lock(fd)
+
+        if attempt < max_attempts:
+            await asyncio.sleep(_RETRY_BACKOFF)
+
+    # Only power-cycle STUCK adapters (not EXTERNAL_SCAN).
+    truly_stuck = {
+        a for a, state in stuck_adapters.items()
+        if state == AdapterScanState.STUCK
+    }
+    if IS_LINUX and truly_stuck:
+        await _last_resort_power_cycle(truly_stuck, effective_adapters)
+
+    return []

--- a/dbus-serialbattery/ext/bleak_connection_manager/validators.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/validators.py
@@ -1,0 +1,222 @@
+"""Built-in connection validators for use with ``establish_connection()``.
+
+Each validator conforms to the ``Callable[[BleakClient], Awaitable[bool]]``
+signature expected by the ``validate_connection`` parameter.  Pick the
+level of validation that suits your use case, or write your own.
+
+Validators are ordered from weakest to strongest:
+
+1. :func:`validate_gatt_services` -- GATT services non-empty.
+2. :func:`validate_char_exists` -- a specific characteristic UUID exists.
+3. :func:`validate_read_char` -- actually reads from a characteristic.
+
+All validators catch exceptions internally and return ``False`` on any
+failure -- they never propagate exceptions to the retry loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from bleak import BleakClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def validate_gatt_services(client: BleakClient) -> bool:
+    """Validate that GATT service discovery completed.
+
+    Returns ``True`` if ``client.services`` is non-empty.  This catches:
+
+    - **Stuck State 9**: Connect succeeded but GATT discovery failed
+      silently -- ``client.services`` is empty.
+    - **Stuck State 17**: GATT resolution race -- connect returned
+      before service discovery finished on slow BLE chips.
+
+    Usage::
+
+        client = await establish_connection(
+            BleakClient, device,
+            validate_connection=validate_gatt_services,
+        )
+    """
+    if not client.services:
+        _LOGGER.debug(
+            "validate_gatt_services: GATT services empty for %s",
+            client.address,
+        )
+        return False
+    return True
+
+
+def validate_char_exists(
+    uuid: str,
+) -> Callable[[BleakClient], Awaitable[bool]]:
+    """Create a validator that checks for a specific characteristic UUID.
+
+    Returns a validator function that confirms GATT services are
+    non-empty *and* that the given characteristic UUID is present.
+    This catches everything :func:`validate_gatt_services` catches,
+    plus partial GATT resolution where the needed characteristic
+    hasn't appeared yet.
+
+    Parameters
+    ----------
+    uuid:
+        The characteristic UUID to look for (case-insensitive).
+
+    Usage::
+
+        client = await establish_connection(
+            BleakClient, device,
+            validate_connection=validate_char_exists(
+                "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+            ),
+        )
+    """
+    target = uuid.lower()
+
+    async def _validator(client: BleakClient) -> bool:
+        if not client.services:
+            _LOGGER.warning(
+                "validate_char_exists(%s): GATT services empty for %s — "
+                "ServicesResolved fired but no services discovered",
+                uuid,
+                client.address,
+            )
+            return False
+
+        for service in client.services:
+            for char in service.characteristics:
+                if char.uuid.lower() == target:
+                    return True
+
+        found_services = []
+        found_chars = []
+        for service in client.services:
+            found_services.append(service.uuid)
+            for char in service.characteristics:
+                found_chars.append(char.uuid)
+
+        _LOGGER.warning(
+            "validate_char_exists(%s): characteristic NOT FOUND for %s — "
+            "GATT has %d services, %d characteristics. "
+            "Services: %s | Characteristics: %s",
+            uuid,
+            client.address,
+            len(found_services),
+            len(found_chars),
+            ", ".join(found_services),
+            ", ".join(found_chars),
+        )
+        return False
+
+    _validator.__doc__ = (
+        f"Validate that characteristic {uuid} exists in GATT services."
+    )
+    return _validator
+
+
+def validate_read_char(
+    uuid: str,
+    timeout: float = 5.0,
+) -> Callable[[BleakClient], Awaitable[bool]]:
+    """Create a validator that reads from a characteristic to prove liveness.
+
+    Returns a validator function that:
+
+    1. Confirms GATT services are non-empty.
+    2. Confirms the characteristic UUID exists.
+    3. Performs an actual ``read_gatt_char()`` to verify the connection
+       is live end-to-end.
+
+    This is the strongest built-in validator.  It catches everything
+    the weaker validators catch, plus:
+
+    - **Stuck State 1**: Phantom connections adopted as "connected" --
+      the read will fail with "Not connected".
+    - **Stuck State 2**: Dead HCI handle -- the read will fail with
+      a transport error.
+    - **Stuck State 5**: Zombie connections (if used during initial
+      validation) -- the read may hang or fail.
+
+    Parameters
+    ----------
+    uuid:
+        The characteristic UUID to read from (must support Read).
+    timeout:
+        Maximum seconds to wait for the read operation.
+
+    Usage::
+
+        client = await establish_connection(
+            BleakClient, device,
+            validate_connection=validate_read_char(
+                "00002a19-0000-1000-8000-00805f9b34fb"  # Battery Level
+            ),
+        )
+    """
+    import asyncio
+
+    target = uuid.lower()
+
+    async def _validator(client: BleakClient) -> bool:
+        if not client.services:
+            _LOGGER.debug(
+                "validate_read_char(%s): GATT services empty for %s",
+                uuid,
+                client.address,
+            )
+            return False
+
+        char_found = False
+        for service in client.services:
+            for char in service.characteristics:
+                if char.uuid.lower() == target:
+                    char_found = True
+                    break
+            if char_found:
+                break
+
+        if not char_found:
+            _LOGGER.debug(
+                "validate_read_char(%s): characteristic not found for %s",
+                uuid,
+                client.address,
+            )
+            return False
+
+        try:
+            data = await asyncio.wait_for(
+                client.read_gatt_char(uuid),
+                timeout=timeout,
+            )
+            _LOGGER.debug(
+                "validate_read_char(%s): read %d bytes from %s",
+                uuid,
+                len(data),
+                client.address,
+            )
+            return True
+        except asyncio.TimeoutError:
+            _LOGGER.debug(
+                "validate_read_char(%s): read timed out after %.1f s for %s",
+                uuid,
+                timeout,
+                client.address,
+            )
+            return False
+        except Exception:
+            _LOGGER.debug(
+                "validate_read_char(%s): read failed for %s",
+                uuid,
+                client.address,
+                exc_info=True,
+            )
+            return False
+
+    _validator.__doc__ = (
+        f"Validate connection by reading characteristic {uuid}."
+    )
+    return _validator

--- a/dbus-serialbattery/ext/bleak_connection_manager/watchdog.py
+++ b/dbus-serialbattery/ext/bleak_connection_manager/watchdog.py
@@ -1,0 +1,305 @@
+"""Connection watchdog for monitoring BLE notification activity.
+
+Detects "zombie" connections where BlueZ still reports Connected=True
+but no notifications are being received — the radio link is effectively
+dead without a disconnect callback ever firing.
+
+The caller must specify the expected timeout because only the caller
+knows the device's notification cadence.  There is no sensible default
+— a battery BMS sends every 1-5 s while a temperature sensor may send
+every 60 s.  Making the timeout explicit forces the caller to think
+about what "dead" means for their specific device.
+
+Usage::
+
+    watchdog = ConnectionWatchdog(
+        timeout=30.0,
+        on_timeout=my_reconnect_callback,
+    )
+    watchdog.start()
+
+    # In your notification callback:
+    watchdog.notify_activity()
+
+    # When done:
+    watchdog.stop()
+
+When *client* and *device* are provided, the watchdog automatically
+tears down the connection at the BlueZ level before invoking the
+callback.  This ensures the next ``establish_connection()`` call
+starts fresh instead of adopting stale state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import re
+import time
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from .bluez import remove_device, verified_disconnect
+from .const import DISCONNECT_TIMEOUT
+
+if TYPE_CHECKING:
+    from bleak import BleakClient
+    from bleak.backends.device import BLEDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _adapter_from_device(device: BLEDevice | None) -> str | None:
+    """Extract the adapter name from a BLEDevice's BlueZ D-Bus path.
+
+    bleak's BlueZ backend stores the object path in ``device.details``
+    (e.g. ``/org/bluez/hci1/dev_AA_BB_...``).  Returns ``None`` when the
+    device has no path (non-BlueZ backend, fabricated device).
+    """
+    details = getattr(device, "details", None)
+    if not isinstance(details, dict):
+        return None
+    match = re.match(r"/org/bluez/(hci\d+)/", details.get("path") or "")
+    return match.group(1) if match else None
+
+
+class ConnectionWatchdog:
+    """Monitor a BLE connection for notification activity.
+
+    Tracks the time since the last :meth:`notify_activity` call.
+    When the timeout is exceeded the optional *on_timeout* callback
+    is invoked so the caller can trigger reconnection or cleanup.
+
+    When *client* and *device* are both provided, the watchdog
+    performs BlueZ-level cleanup before invoking the callback:
+
+    1. ``client.disconnect()`` with a 5 s timeout (prevents hang
+       on phantom connections).
+    2. ``remove_device()`` via D-Bus to clear BlueZ cache.
+    3. The *on_timeout* callback, where the caller can reconnect.
+
+    Firing semantics: the watchdog is **one-shot on success** — after
+    the cleanup and a callback invocation that does not raise, the
+    monitoring task exits, and a new watchdog must be created for the
+    next connection.  If the callback *raises*, the watchdog re-arms
+    and retries after another full timeout instead of dying silently;
+    the most recent failure is exposed as :attr:`last_callback_error`.
+
+    .. warning::
+        The cleanup calls ``remove_device()``, which deletes the BlueZ
+        device object.  The caller's ``BleakClient`` never receives a
+        property-change signal for that deletion, so its cached
+        ``is_connected`` may remain ``True`` indefinitely.  Do not use
+        ``client.is_connected`` as a loop condition to detect this
+        watchdog firing — drive reconnection from the *on_timeout*
+        callback (or from your own data-freshness check).
+
+    Parameters
+    ----------
+    timeout:
+        Seconds of inactivity before the watchdog fires.  Required —
+        there is no default because only the caller knows the device's
+        expected notification cadence.
+    on_timeout:
+        Callback invoked when the timeout expires.  May be a plain
+        callable or a coroutine function; a returned awaitable is
+        awaited.
+    client:
+        The connected ``BleakClient``.
+    device:
+        The ``BLEDevice`` for the connection.
+    adapter:
+        The adapter the connection lives on (e.g. ``"hci1"``).  If
+        ``None``, derived from the device's BlueZ D-Bus path, falling
+        back to ``hci0``.  Cleanup must target the right adapter or
+        the D-Bus calls silently miss the stale device object.
+    """
+
+    def __init__(
+        self,
+        timeout: float,
+        on_timeout: Callable[[], Awaitable[None]] | None = None,
+        client: BleakClient | None = None,
+        device: BLEDevice | None = None,
+        adapter: str | None = None,
+    ) -> None:
+        self._timeout = timeout
+        self._on_timeout = on_timeout
+        self._client = client
+        self._device = device
+        self._adapter = adapter
+        self._last_activity: float = 0.0
+        self._task: asyncio.Task[None] | None = None
+        self._started = False
+        self._last_callback_error: BaseException | None = None
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the watchdog is actively monitoring."""
+        return self._started and self._task is not None and not self._task.done()
+
+    @property
+    def last_activity(self) -> float:
+        """Return the monotonic timestamp of the last activity."""
+        return self._last_activity
+
+    @property
+    def last_callback_error(self) -> BaseException | None:
+        """Return the exception from the most recent failed *on_timeout* call.
+
+        ``None`` if the callback has not failed (or succeeded on a
+        retry).  While this is non-``None`` the watchdog is re-arming
+        and retrying the callback after each timeout period.
+        """
+        return self._last_callback_error
+
+    def notify_activity(self) -> None:
+        """Record that a notification or other activity was received.
+
+        Call this from your BLE notification callback to reset the
+        watchdog timer.
+        """
+        self._last_activity = time.monotonic()
+
+    def start(self) -> None:
+        """Start the watchdog monitoring loop.
+
+        Records the current time as the initial activity timestamp and
+        creates an asyncio task for the monitoring loop.  Calling
+        ``start()`` on an already-running watchdog is a no-op.
+        """
+        if self._started:
+            return
+        self._last_activity = time.monotonic()
+        self._started = True
+        self._task = asyncio.ensure_future(self._monitor())
+
+    def stop(self) -> None:
+        """Stop the watchdog.
+
+        Cancels the monitoring task.  Safe to call multiple times or
+        before ``start()``.
+        """
+        self._started = False
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def _cleanup_connection(self) -> None:
+        """Disconnect the client and verify via D-Bus, then clear cache.
+
+        Called when *client* and *device* were provided and the
+        inactivity timeout has fired.
+
+        Uses a two-step approach:
+
+        1. ``client.disconnect()`` with a timeout (prevents phantom hang).
+        2. ``verified_disconnect()`` polls D-Bus ``Connected`` property
+           to confirm the device is truly disconnected.  If still
+           connected, escalates to ``remove_device()`` automatically.
+        3. Final ``remove_device()`` to clear BlueZ cache for a fresh
+           reconnect.
+        """
+        if self._client is None or self._device is None:
+            return
+        address = self._device.address
+        adapter = self._adapter or _adapter_from_device(self._device) or "hci0"
+
+        # Step 1: disconnect with timeout (prevents phantom hang)
+        try:
+            await asyncio.wait_for(
+                self._client.disconnect(), timeout=DISCONNECT_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.debug(
+                "ConnectionWatchdog: disconnect timed out for %s,"
+                " proceeding to verified disconnect",
+                address,
+            )
+        except Exception:
+            _LOGGER.debug(
+                "ConnectionWatchdog: disconnect failed for %s,"
+                " proceeding to verified disconnect",
+                address,
+                exc_info=True,
+            )
+
+        # Step 2: verify D-Bus agrees the device is disconnected;
+        # if still Connected=True, escalates to remove_device internally
+        try:
+            await verified_disconnect(
+                address, adapter, timeout=DISCONNECT_TIMEOUT
+            )
+        except Exception:
+            _LOGGER.debug(
+                "ConnectionWatchdog: verified_disconnect failed for %s",
+                address,
+                exc_info=True,
+            )
+
+        # Step 3: remove device from BlueZ so next connect starts fresh
+        try:
+            await remove_device(address, adapter)
+        except Exception:
+            _LOGGER.debug(
+                "ConnectionWatchdog: remove_device failed for %s",
+                address,
+                exc_info=True,
+            )
+
+    async def _monitor(self) -> None:
+        """Internal monitoring loop.
+
+        Wakes up periodically and checks whether the inactivity timeout
+        has been exceeded.  Uses a check interval of half the timeout
+        (clamped to 1–30 s) so the actual fire time is at most one
+        interval late.
+        """
+        check_interval = min(self._timeout / 2, 30.0)
+        try:
+            while self._started:
+                await asyncio.sleep(check_interval)
+                elapsed = time.monotonic() - self._last_activity
+                if elapsed < self._timeout:
+                    continue
+
+                _LOGGER.warning(
+                    "ConnectionWatchdog: no activity for %.1f s (timeout %.1f s)",
+                    elapsed,
+                    self._timeout,
+                )
+
+                # Cleanup is repeated on each retry after a callback
+                # failure — the bluez helpers tolerate an already-
+                # removed device, and stale state may have reappeared.
+                if self._client is not None and self._device is not None:
+                    await self._cleanup_connection()
+
+                if self._on_timeout is not None:
+                    try:
+                        # Accept both plain callables and coroutine
+                        # functions — a sync callback returns None,
+                        # which must not be awaited.
+                        result = self._on_timeout()
+                        if inspect.isawaitable(result):
+                            await result
+                    except Exception as exc:
+                        # A failed recovery hook must not end monitoring:
+                        # the connection is still down.  Re-arm and keep
+                        # retrying (and nagging the log) until the
+                        # callback succeeds or stop() is called.
+                        self._last_callback_error = exc
+                        self._last_activity = time.monotonic()
+                        _LOGGER.exception(
+                            "ConnectionWatchdog: on_timeout callback failed"
+                            " — re-arming, retrying in %.1f s",
+                            self._timeout,
+                        )
+                        continue
+                    self._last_callback_error = None
+                break
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._started = False

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -261,6 +261,7 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 # --------- Bluetooth BMS ---------
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
+BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -262,6 +262,9 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
 BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
+# Bluetooth adapters (hciX) to use for BLE BMS connections, tried in order.
+# Empty list = use the system default adapter.
+BLUETOOTH_ADAPTERS: List[str] = get_list_from_config("DEFAULT", "BLUETOOTH_ADAPTERS", str)
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -5,7 +5,84 @@ import sys
 from bleak import BleakClient
 from bleak.exc import BleakCharacteristicNotFoundError
 from time import sleep
-from utils import logger, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+
+
+class BleConnectionBackend:
+    """
+    Interface for establishing and releasing BLE connections.
+
+    Separates how a connection is established/torn down (the backend) from how
+    Syncron_Ble supervises it and exchanges data with the BMS drivers. This allows
+    alternative connection strategies to be plugged in without touching the drivers.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        """
+        Create the BleakClient for the given address, or None if the backend
+        creates its own client during establish().
+        """
+        raise NotImplementedError
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        """
+        Connect and start notifications. Returns the connected client
+        (may differ from the one passed in). Raises on failure.
+        """
+        raise NotImplementedError
+
+    async def release(self, client):
+        """Disconnect the client."""
+        raise NotImplementedError
+
+
+class BleakBackend(BleConnectionBackend):
+    """
+    Default backend: connects directly with bleak, matching the historical
+    behavior of this driver.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        return BleakClient(address, disconnected_callback=disconnected_callback)
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        logger.info("initiating BLE connection to: " + address)
+        await client.connect()
+        logger.info("connected to bluetooh device" + address)
+        # On some devices GATT characteristics become available only after connect()
+        # has already returned, so the first start_notify() can raise
+        # BleakCharacteristicNotFoundError for a characteristic that does exist.
+        # Re-run service discovery and retry before giving up.
+        for attempt in range(3):
+            try:
+                await client.start_notify(notify_char, notify_callback)
+                break
+            except BleakCharacteristicNotFoundError:
+                if attempt == 2:
+                    raise
+                logger.warning(f"characteristic {notify_char} not found yet, re-running service discovery")
+                # bleak has no public API to re-run service discovery on a connected
+                # client; clear the cached services so _get_services() fetches again
+                client._backend.services = None
+                await client._backend._get_services()
+                await asyncio.sleep(0.5)
+        return client
+
+    async def release(self, client):
+        await client.disconnect()
+
+
+# Available connection backends, selected by class name via BLUETOOTH_CONNECTION_BACKEND
+supported_ble_backends = [BleakBackend]
+
+
+def get_ble_backend():
+    """Return the connection backend selected by BLUETOOTH_CONNECTION_BACKEND."""
+    for backend in supported_ble_backends:
+        if backend.__name__ == BLUETOOTH_CONNECTION_BACKEND:
+            return backend()
+    logger.warning(f"Unknown BLUETOOTH_CONNECTION_BACKEND '{BLUETOOTH_CONNECTION_BACKEND}', using 'BleakBackend'")
+    return BleakBackend()
 
 
 # Class that enables synchronous writing and reading to a bluetooh device
@@ -35,6 +112,7 @@ class Syncron_Ble:
         self.write_characteristic = write_characteristic
         self.read_characteristic = read_characteristic
         self.address = address
+        self.backend = get_ble_backend()
 
         # Start a new thread that will run bleak the async bluetooth LE library
         self.main_thread = threading.current_thread()
@@ -66,37 +144,19 @@ class Syncron_Ble:
         logger.error(f"bluetooh device with address: {self.address} disconnected")
 
     async def connect_to_bms(self, address):
-        self.client = BleakClient(address, disconnected_callback=self.client_disconnected)
+        self.client = self.backend.create_client(address, self.client_disconnected)
         try:
-            logger.info("initiating BLE connection to: " + address)
-            await self.client.connect()
-            logger.info("connected to bluetooh device" + address)
-            # On some devices GATT characteristics become available only after connect()
-            # has already returned, so the first start_notify() can raise
-            # BleakCharacteristicNotFoundError for a characteristic that does exist.
-            # Re-run service discovery and retry before giving up.
-            for attempt in range(3):
-                try:
-                    await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
-                    break
-                except BleakCharacteristicNotFoundError:
-                    if attempt == 2:
-                        raise
-                    logger.warning(f"characteristic {self.read_characteristic} not found yet, re-running service discovery")
-                    # bleak has no public API to re-run service discovery on a connected
-                    # client; clear the cached services so _get_services() fetches again
-                    self.client._backend.services = None
-                    await self.client._backend._get_services()
-                    await asyncio.sleep(0.5)
+            self.client = await self.backend.establish(self.client, address, self.read_characteristic, self.notify_read_callback)
 
         except Exception as e:
             logger.error("Failed when trying to connect", e)
             return False
         finally:
             self.ble_connection_ready.set()
-            while self.client.is_connected and self.main_thread.is_alive():
-                await asyncio.sleep(0.1)
-            await self.client.disconnect()
+            if self.client:
+                while self.client.is_connected and self.main_thread.is_alive():
+                    await asyncio.sleep(0.1)
+                await self.backend.release(self.client)
 
     # saves response and tells the command sender that the response has arived
     def notify_read_callback(self, sender, data: bytearray):

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -113,14 +113,18 @@ class Syncron_Ble:
         self.response_event = False
         return self.response_data
 
-    async def send_coroutine_to_ble_thread_and_wait_for_result(self, coroutine):
-        bt_task = asyncio.run_coroutine_threadsafe(coroutine, self.ble_async_thread_event_loop)
-        result = await asyncio.wait_for(asyncio.wrap_future(bt_task), timeout=1.5)
-        return result
-
     def send_data(self, data):
-        data = asyncio.run(self.send_coroutine_to_ble_thread_and_wait_for_result(self.ble_thread_send_com(data)))
-        return data
+        # Schedule the write on the BLE thread's existing event loop and wait
+        # for the result directly. The previous implementation wrapped this in
+        # asyncio.run(), constructing and tearing down a whole event loop for
+        # every command sent — measurable CPU overhead on GX hardware for
+        # drivers that poll several commands every few seconds.
+        future = asyncio.run_coroutine_threadsafe(self.ble_thread_send_com(data), self.ble_async_thread_event_loop)
+        try:
+            return future.result(timeout=1.5)
+        except Exception:
+            future.cancel()
+            raise
 
 
 def restart_ble_hardware_and_bluez_driver():

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -90,8 +90,194 @@ class BleakBackend(BleConnectionBackend):
         await client.disconnect()
 
 
+try:
+    from bleak_connection_manager import (
+        PROFILE_BATTERY,
+        EscalationPolicy,
+        establish_connection,
+    )
+    from bleak_connection_manager.adapters import discover_adapters
+    from bleak_connection_manager.scanner import find_device as bcm_find_device
+
+    _HAS_BCM = True
+except Exception as e:  # pragma: no cover - import guard
+    _HAS_BCM = False
+    _BCM_IMPORT_ERROR = e
+
+
+class BCMBackend(BleConnectionBackend):
+    """
+    bleak-connection-manager backend: managed connection lifecycle for hosts
+    where the direct bleak path is unreliable (GX devices with several BLE
+    services fighting over adapters).
+
+    Adds over BleakBackend:
+      - cache-first device resolution (no StartDiscovery when the device is
+        already in the BlueZ cache; scan-lock coordination when it isn't)
+      - connect retries with per-adapter failure tracking and escalation
+        (PROFILE_BATTERY policy)
+      - adapter selection from BLUETOOTH_ADAPTERS, or auto-discovery of all
+        adapters when unset
+      - phantom-connection cleanup before attempts
+    """
+
+    def __init__(self):
+        if not _HAS_BCM:
+            logger.error(f"BCMBackend selected but bleak_connection_manager is not importable: {_BCM_IMPORT_ERROR}")
+            raise ImportError(_BCM_IMPORT_ERROR)
+
+    def _adapters(self):
+        if BLUETOOTH_ADAPTERS:
+            return list(BLUETOOTH_ADAPTERS)
+        try:
+            return discover_adapters()
+        except Exception as e:
+            logger.warning(f"BLE: adapter discovery failed ({e}), using system default")
+            return None
+
+    def create_client(self, address, disconnected_callback):
+        # BCM creates and returns its own client during establish()
+        self._disconnected_callback = disconnected_callback
+        return None
+
+    async def _connect_device_no_scan(self, address, adapter):
+        """Create + connect the device object on a specific adapter via
+        BlueZ's experimental Adapter1.ConnectDevice (bluetoothd -E).
+
+        Returns the device object path, or None on failure.  Unlike a
+        discovery scan, this does not need the adapter's scan slot, so it
+        works while other services hold scanning on the adapter.
+        """
+        try:
+            from dbus_fast import Message, Variant
+            from dbus_fast.aio import MessageBus
+            from dbus_fast.constants import BusType, MessageType
+
+            bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+            try:
+                reply = await asyncio.wait_for(
+                    bus.call(
+                        Message(
+                            destination="org.bluez",
+                            path=f"/org/bluez/{adapter}",
+                            interface="org.bluez.Adapter1",
+                            member="ConnectDevice",
+                            signature="a{sv}",
+                            body=[{"Address": Variant("s", address), "AddressType": Variant("s", "public")}],
+                        )
+                    ),
+                    timeout=30.0,
+                )
+                if reply.message_type == MessageType.METHOD_RETURN:
+                    return reply.body[0] if reply.body else f"/org/bluez/{adapter}/dev_" + address.replace(":", "_").upper()
+                error_name = getattr(reply, "error_name", "")
+                if "AlreadyExists" in error_name:
+                    # device object already present on this adapter — usable
+                    return f"/org/bluez/{adapter}/dev_" + address.replace(":", "_").upper()
+                logger.debug(f"BLE [{address}] ConnectDevice on {adapter} failed: {error_name}")
+                return None
+            finally:
+                bus.disconnect()
+        except Exception as e:
+            logger.debug(f"BLE [{address}] ConnectDevice on {adapter} error: {repr(e)}")
+            return None
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        adapters = self._adapters()
+        escalation = EscalationPolicy(adapters or [], config=PROFILE_BATTERY)
+
+        # Cache-first device resolution; scan only if the cache misses and
+        # the scan lock can be acquired.  BLUETOOTH_ADAPTERS is a hard
+        # allow-list: connections are made ONLY via the listed adapters.
+        # When the listed adapters cannot resolve the device by scanning
+        # (their scan slots are frequently held by other services on GX
+        # hardware), fall back to BlueZ's ConnectDevice API, which creates
+        # and connects the device object on a chosen adapter without any
+        # discovery (requires bluetoothd -E, standard on Venus OS).
+        device = None
+        try:
+            device = await bcm_find_device(address, timeout=15.0, max_attempts=2, adapters=adapters)
+        except Exception as e:
+            logger.warning(f"BLE [{address}] managed scan failed: {repr(e)}")
+
+        connect_adapters = adapters
+        if device is not None:
+            # Pin the connection to the adapter holding the device object.
+            # The cache-first resolution can return an object cached on a
+            # NON-allowed adapter (e.g. left over from an earlier connection
+            # there) — reject and remove those so they stop shadowing the
+            # allowed adapters, and fall through to ConnectDevice instead.
+            try:
+                found_adapter = device.details["path"].split("/")[3]
+                if adapters and found_adapter not in adapters:
+                    logger.info(f"BLE [{address}] cached on disallowed {found_adapter} — removing and using ConnectDevice on allowed adapters")
+                    try:
+                        from bleak_connection_manager.bluez import remove_device
+
+                        await remove_device(address, found_adapter)
+                    except Exception:
+                        pass
+                    device = None
+                else:
+                    connect_adapters = [found_adapter]
+            except Exception:
+                pass
+        if device is None:
+            for adapter in adapters or ["hci0"]:
+                path = await self._connect_device_no_scan(address, adapter)
+                if path:
+                    from bleak.backends.device import BLEDevice
+
+                    logger.info(f"BLE [{address}] created device on {adapter} via ConnectDevice (no scan)")
+                    device = BLEDevice(address=address, name=None, details={"path": path, "props": {}})
+                    connect_adapters = [adapter]
+                    break
+            if device is None:
+                raise Exception(f"device not resolvable on allowed adapters {adapters} (scan + ConnectDevice both failed)")
+
+        client = await establish_connection(
+            BleakClient,
+            device,
+            f"serialbattery {address}",
+            disconnected_callback=self._disconnected_callback,
+            max_attempts=5,
+            adapters=connect_adapters,
+            close_inactive_connections=True,
+            escalation_policy=escalation,
+            overall_timeout=240.0,
+            timeout=15.0,
+        )
+        logger.info(f"BLE [{address}] connected via BCM")
+
+        try:
+            await asyncio.wait_for(client.start_notify(notify_char, notify_callback), timeout=10.0)
+        except Exception as e:
+            logger.warning(f"BLE [{address}] start_notify failed: {repr(e)}")
+            # A stale BlueZ cache entry can produce a client that claims to
+            # be connected but has no live link. Clear it so the next
+            # attempt performs a fresh connect.
+            if "Not connected" in str(e):
+                try:
+                    from bleak_connection_manager.bluez import remove_device
+
+                    for adap in adapters or ["hci0"]:
+                        await remove_device(address, adap)
+                    logger.info(f"BLE [{address}] cleared stale BlueZ cache entry")
+                except Exception:
+                    pass
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+            raise
+        return client
+
+    async def release(self, client):
+        await client.disconnect()
+
+
 # Available connection backends, selected by class name via BLUETOOTH_CONNECTION_BACKEND
-supported_ble_backends = [BleakBackend]
+supported_ble_backends = [BleakBackend, BCMBackend]
 
 
 def get_ble_backend():

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -5,7 +5,7 @@ import sys
 from bleak import BleakClient
 from bleak.exc import BleakCharacteristicNotFoundError
 from time import sleep
-from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_ADAPTERS, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
 
 
 class BleConnectionBackend:
@@ -40,32 +40,50 @@ class BleakBackend(BleConnectionBackend):
     """
     Default backend: connects directly with bleak, matching the historical
     behavior of this driver.
+
+    If BLUETOOTH_ADAPTERS is set, connections are made only via the listed
+    adapters, rotating to the next entry after a failed attempt. An empty
+    list uses the system default adapter.
     """
 
+    def __init__(self):
+        self.adapter_index = 0
+        self.current_adapter = None
+
     def create_client(self, address, disconnected_callback):
-        return BleakClient(address, disconnected_callback=disconnected_callback)
+        kwargs = {}
+        if BLUETOOTH_ADAPTERS:
+            self.current_adapter = BLUETOOTH_ADAPTERS[self.adapter_index % len(BLUETOOTH_ADAPTERS)]
+            kwargs["adapter"] = self.current_adapter
+        return BleakClient(address, disconnected_callback=disconnected_callback, **kwargs)
 
     async def establish(self, client, address, notify_char, notify_callback):
-        logger.info("initiating BLE connection to: " + address)
-        await client.connect()
-        logger.info("connected to bluetooh device" + address)
-        # On some devices GATT characteristics become available only after connect()
-        # has already returned, so the first start_notify() can raise
-        # BleakCharacteristicNotFoundError for a characteristic that does exist.
-        # Re-run service discovery and retry before giving up.
-        for attempt in range(3):
-            try:
-                await client.start_notify(notify_char, notify_callback)
-                break
-            except BleakCharacteristicNotFoundError:
-                if attempt == 2:
-                    raise
-                logger.warning(f"characteristic {notify_char} not found yet, re-running service discovery")
-                # bleak has no public API to re-run service discovery on a connected
-                # client; clear the cached services so _get_services() fetches again
-                client._backend.services = None
-                await client._backend._get_services()
-                await asyncio.sleep(0.5)
+        logger.info("initiating BLE connection to: " + address + (f" (adapter {self.current_adapter})" if self.current_adapter else ""))
+        try:
+            await client.connect()
+            logger.info("connected to bluetooh device" + address)
+            # On some devices GATT characteristics become available only after connect()
+            # has already returned, so the first start_notify() can raise
+            # BleakCharacteristicNotFoundError for a characteristic that does exist.
+            # Re-run service discovery and retry before giving up.
+            for attempt in range(3):
+                try:
+                    await client.start_notify(notify_char, notify_callback)
+                    break
+                except BleakCharacteristicNotFoundError:
+                    if attempt == 2:
+                        raise
+                    logger.warning(f"characteristic {notify_char} not found yet, re-running service discovery")
+                    # bleak has no public API to re-run service discovery on a connected
+                    # client; clear the cached services so _get_services() fetches again
+                    client._backend.services = None
+                    await client._backend._get_services()
+                    await asyncio.sleep(0.5)
+        except Exception:
+            # rotate to the next configured adapter for the next attempt
+            if BLUETOOTH_ADAPTERS:
+                self.adapter_index += 1
+            raise
         return client
 
     async def release(self, client):

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -3,6 +3,7 @@ import asyncio
 import subprocess
 import sys
 from bleak import BleakClient
+from bleak.exc import BleakCharacteristicNotFoundError
 from time import sleep
 from utils import logger, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
 
@@ -70,7 +71,23 @@ class Syncron_Ble:
             logger.info("initiating BLE connection to: " + address)
             await self.client.connect()
             logger.info("connected to bluetooh device" + address)
-            await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
+            # On some devices GATT characteristics become available only after connect()
+            # has already returned, so the first start_notify() can raise
+            # BleakCharacteristicNotFoundError for a characteristic that does exist.
+            # Re-run service discovery and retry before giving up.
+            for attempt in range(3):
+                try:
+                    await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
+                    break
+                except BleakCharacteristicNotFoundError:
+                    if attempt == 2:
+                        raise
+                    logger.warning(f"characteristic {self.read_characteristic} not found yet, re-running service discovery")
+                    # bleak has no public API to re-run service discovery on a connected
+                    # client; clear the cached services so _get_services() fetches again
+                    self.client._backend.services = None
+                    await self.client._backend._get_services()
+                    await asyncio.sleep(0.5)
 
         except Exception as e:
             logger.error("Failed when trying to connect", e)


### PR DESCRIPTION
## What

Adds **BCMBackend**, an opt-in BLE connection backend selected via `BLUETOOTH_CONNECTION_BACKEND = BCMBackend`, built on a vendored copy of [bleak-connection-manager](https://github.com/TechBlueprints/bleak-connection-manager) in `ext/`. The backend is import-guarded: if the package is absent or the option is not selected, nothing changes. **Zero behavior change for existing installs** — the default stays `BleakBackend`.

What BCMBackend adds over the direct bleak path:

- **Cache-first device resolution** via managed scanning — no `StartDiscovery` at all when the device is already in the BlueZ cache; scan-lock coordination when it isn't.
- **Scan-free connects** via BlueZ's `Adapter1.ConnectDevice` (experimental API, `bluetoothd -E` — standard on Venus OS): creates and connects the device object on a chosen adapter without needing a scan slot.
- **Strict `BLUETOOTH_ADAPTERS` allow-list semantics**: connections are made only via the listed adapters; device objects found cached on disallowed adapters are rejected and removed so they stop shadowing the allowed ones.
- **Managed connection establishment** with retries, per-adapter failure tracking, and escalation (`PROFILE_BATTERY` policy), phantom-connection cleanup, and a 240 s overall timeout.
- **Stale BlueZ cache recovery**: a "Not connected" failure on `start_notify` clears the stale device object so the next attempt performs a fresh connect.

## Why

Real-world evidence from 2026-08-11/12 on a production Cerbo GX MK2 with 4 Bluetooth adapters and several concurrent BLE services:

- bleak's default connect path requires a discovery scan first. On GX devices, other services (VE.SmartNetworking, Ruuvi scanning, etc.) hold adapter scan slots, so the scan fails with **indefinite `org.bluez.Error.InProgress`** and the driver can never connect.
- Clone-dongle firmware (RTL8851BU-class) additionally **deadlocks its scan state machine** under scan churn (kernel log: `Opcode 0x2042 failed: -16` repeating) until the adapter is reset — scanning less isn't just faster, it keeps the adapter alive.
- BCMBackend survived where the direct path could not: cache-first resolution avoids scans entirely when possible, `ConnectDevice` needs no scan slot at all, and the strict adapter allow-list keeps BMS links off adapters that other services destabilize (e.g. built-in Wi-Fi/BT combo modules whose coexistence events drop all LE links simultaneously — see victronenergy/venus#1618).

## Relationship to other PRs

Stacks on #493 + #494 (backend seam) + #497 (`BLUETOOTH_ADAPTERS`) — the review is effectively the **last commit only**; I will rebase as those land. Sibling of #501 (same stack base).

This addresses the #447 proposal ("BCM in `/ext`") in the maintainer-preferred opt-in form (per the #446 discussion).

## Vendoring

`ext/bleak_connection_manager` is vendored following the repo's existing `ext/` convention (`bleak`, `bleak_retry_connector`, `bluetooth_adapters` are already vendored there). It depends only on already-vendored packages plus system `dbus_fast`, which ships in Venus OS.

## Testing

Soaking on a production Cerbo GX MK2 since 2026-08-12 05:33 UTC as the only connection path for two HumsiENK BLE BMS links. I will update this PR with multi-day soak results before marking it ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
