### PR TITLE
Add HumsiENK BLE battery driver (stacked on BLE infrastructure PRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte
 * Added: dbus caching to reduce writes and therefore CPU consumption with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/397 by @cgoudie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 * Added: `/CapacityBms` and `/ConsumedAmphoursBms` D-Bus paths to expose the raw BMS remaining/consumed Ah values alongside the calculated ones when `SOC_CALCULATION` or `EXTERNAL_SENSOR_DBUS_PATH_SOC` is active, mirroring the existing `/SocBms` path. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/414 by @mr-manuel
 * Added: aiobmsble library (https://github.com/patman15/aiobmsble), which adds a lot of Bluetooth batteries to Venus OS by @mr-manuel
+* Added: `BLUETOOTH_ADAPTERS` config option to restrict Bluetooth LE BMS connections to specific adapters (hciX), rotating to the next listed adapter after a failed attempt. Helps on GX devices with multiple adapters where the default adapter is contended or unstable by @cgoudie
 * Added: `BLUETOOTH_CONNECTION_BACKEND` config option to select how Bluetooth LE connections are established. Currently only `BleakBackend` (the existing behavior) is available by @cgoudie
 * Added: BMS auto detection caching - the last detected BMS type per serial port is cached to disk and tried first on the next start, falling back to the full auto detection scan if it's not found after 3 tries by @mr-manuel
 * Added: Daren 485 BMS - Read SoH with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/344 by @kopierschnitte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Added: Disable serial starter if not needed by @mr-manuel
 * Added: Generic MQTT BMS by @mr-manuel
 * Added: Health check for batteries which are using the callback by @mr-manuel
+* Added: HumsiENK BLE BMS by @cgoudie
 * Added: JBD CAN protocol support with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/363 by @dmitrych5
 * Added: JBD UP16S series support, including daisy-chaining, with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/375 by @dmitrych5
 * Added: JK Inverter BMS - Heating informations with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/367 by @BitSeb

--- a/dbus-serialbattery/bms/humsienk_ble.py
+++ b/dbus-serialbattery/bms/humsienk_ble.py
@@ -172,7 +172,7 @@ class HumsiENK_Ble(Battery):
         return "SerialBattery(" + self.type + ") " + self.address[-5:]
 
     def unique_identifier(self) -> str:
-        return self.address.replace(":", "").lower()
+        return self.address
 
     def test_connection(self):
         """

--- a/dbus-serialbattery/bms/humsienk_ble.py
+++ b/dbus-serialbattery/bms/humsienk_ble.py
@@ -1,0 +1,614 @@
+# -*- coding: utf-8 -*-
+
+"""HumsiENK BLE battery driver.
+
+Read-only driver for HumsiENK BLE batteries, using the existing
+utils_ble.Syncron_Ble helper for BLE I/O.
+
+The HumsiENK BLE wire protocol — GATT service / characteristic UUIDs,
+[0xAA, CMD, LEN, DATA, CHK_LO, CHK_HI] frame format, command codes,
+register maps for the 0x21 / 0x20 / 0x22 / 0x58 responses, and the
+operation_status bit definitions — is documented in the aiobmsble
+project:
+
+  https://github.com/patman15/aiobmsble/blob/main/docs/humsienk_bms.md
+  https://github.com/patman15/aiobmsble/blob/main/aiobmsble/bms/humsienk_bms.py
+
+The same protocol was contributed to aiobmsble in parallel with this
+driver; the two implementations decode the same frames. This driver
+exists for users who want a standalone driver via the serialbatteries
+Syncron_Ble path while the aiobmsble integration in serialbatteries is
+being worked through separately.
+"""
+
+from battery import Battery, Cell
+from collections import deque
+from utils import logger, capture_raw_data
+from utils_ble import Syncron_Ble
+import asyncio
+import sys
+import threading
+import time
+
+
+class HumsiENK_Syncron_Ble(Syncron_Ble):
+    """Syncron_Ble adapted to a BMS that streams notifications.
+
+    Syncron_Ble is built for request/response BMS: it keeps a single
+    response slot (response_data) that the next notification overwrites.
+    The HumsiENK BMS instead streams frames continuously once the vendor
+    handshake has been sent, and one logical frame regularly spans several
+    notifications, so this subclass adds:
+
+      - a notification queue, so no chunk is lost between poll cycles
+      - live `connected` tracking, so the driver only writes to the
+        characteristic while the link is actually up (the stock class sets
+        `connected` once, in __init__, from the initial 10 s wait)
+      - a data watchdog: because notifications are unsolicited, a link can
+        stay "connected" while the stream is dead, and only a reconnect
+        recovers it (Jkbms_Ble handles the same failure by resetting the
+        BLE stack after 30 s without data)
+    """
+
+    # Longest silence tolerated on an established link before it is dropped
+    # so the Syncron_Ble reconnect loop can rebuild it.
+    WATCHDOG_TIMEOUT = 180.0
+
+    # Upper bounds on the connect and teardown awaits, so neither can park the
+    # reconnect loop. The backend's own timeouts should always fire first.
+    CONNECT_TIMEOUT = 300.0
+    RELEASE_TIMEOUT = 30.0
+
+    def __init__(self, *args, **kwargs):
+        self._notification_queue = deque(maxlen=256)
+        self._notification_signal = threading.Condition()
+        self._watchdog_last_fed = time.time()
+        super().__init__(*args, **kwargs)
+
+    def feed_watchdog(self) -> None:
+        self._watchdog_last_fed = time.time()
+
+    def get_notification(self, timeout: float = 0.0):
+        """Pop the next queued notification chunk, waiting up to timeout seconds."""
+        with self._notification_signal:
+            if not self._notification_queue and timeout > 0:
+                self._notification_signal.wait(timeout)
+            if self._notification_queue:
+                return self._notification_queue.popleft()
+        return None
+
+    def notify_read_callback(self, sender, data: bytearray) -> None:
+        capture_raw_data(self.address, "rx", data)
+        with self._notification_signal:
+            self._notification_queue.append(bytes(data))
+            self._notification_signal.notify_all()
+        # Keep the stock request/response contract that send_data() relies on
+        if self.response_event:
+            self.response_data = data
+            self.response_event.set()
+
+    async def connect_to_bms(self, address):
+        self.client = self.backend.create_client(address, self.client_disconnected)
+        try:
+            # The reconnect loop in async_main only turns while this returns, so
+            # neither the connect nor the teardown may await without a bound: a
+            # single stalled D-Bus call would otherwise park reconnection for good.
+            self.client = await asyncio.wait_for(
+                self.backend.establish(self.client, address, self.read_characteristic, self.notify_read_callback), timeout=self.CONNECT_TIMEOUT
+            )
+            self.feed_watchdog()
+            self.connected = True
+        except Exception as e:
+            logger.error(f"Failed when trying to connect: {e}")
+            return False
+        finally:
+            self.ble_connection_ready.set()
+            try:
+                if self.client:
+                    while self.client.is_connected and self.main_thread.is_alive():
+                        if self.connected and (time.time() - self._watchdog_last_fed) > self.WATCHDOG_TIMEOUT:
+                            logger.error(f"HumsiENK: no data for {self.WATCHDOG_TIMEOUT:.0f} s on an open link, dropping it to reconnect")
+                            break
+                        await asyncio.sleep(0.1)
+            finally:
+                self.connected = False
+                if self.client:
+                    try:
+                        await asyncio.wait_for(self.backend.release(self.client), timeout=self.RELEASE_TIMEOUT)
+                    except Exception as e:
+                        logger.debug(f"HumsiENK: releasing the connection failed: {repr(e)}")
+
+
+class HumsiENK_Ble(Battery):
+    BATTERYTYPE = "HumsiENK BLE"
+
+    # BLE service and characteristic UUIDs (RX/TX named from the driver's
+    # perspective, not the device's)
+    BLE_SERVICE_UUID = "00000001-0000-1000-8000-00805f9b34fb"
+    BLE_RX_UUID = "00000003-0000-1000-8000-00805f9b34fb"  # notifications arrive here
+    BLE_TX_UUID = "00000002-0000-1000-8000-00805f9b34fb"  # commands are written here
+
+    # Protocol command codes
+    CMD_HANDSHAKE = 0x00  # starts the notification stream
+    CMD_STATUS = 0x20  # operating status (FETs, protections, balancing)
+    CMD_BATTERY_INFO = 0x21  # voltage, current, SOC, SOH, capacity, cycles, temperatures
+    CMD_CELL_VOLTAGES = 0x22  # individual cell voltages
+    CMD_CONFIG = 0x58  # configuration (cell count, capacity, protection limits)
+    CMD_VERSION = 0xF5  # firmware version (ASCII)
+
+    FRAME_START = 0xAA
+    MAX_FRAME_DATA_LENGTH = 200
+
+    # Data older than this counts as a refresh failure, so the framework's
+    # normal disconnect handling engages instead of the driver republishing
+    # values the radio never delivered. Jkbms_Ble reports stale data on the
+    # same threshold.
+    DATA_FRESHNESS_SECONDS = 15.0
+
+    # The vendor app requests all three data commands every 3 s.
+    POLL_INTERVAL_SECONDS = 3.0
+
+    # Shortest interval between handshake re-sends while the stream is starved.
+    HANDSHAKE_RETRY_SECONDS = 30.0
+
+    def __init__(self, port, baud, address):
+        super(HumsiENK_Ble, self).__init__(port, baud, address)
+        self.type = self.BATTERYTYPE
+        self.address = address
+        self.poll_interval = 1000
+        self.ble_handle = None
+        self.history.exclude_values_to_calculate = ["charge_cycles"]
+        self._rx_buffer = bytearray()
+        self._last_frame_time = 0.0  # last checksum-verified frame from the radio
+        self._last_poll_time = 0.0
+        self._last_handshake_time = 0.0
+
+        logger.info("Init of HumsiENK_Ble at " + address)
+
+    def connection_name(self) -> str:
+        return "BLE " + self.address
+
+    def custom_name(self) -> str:
+        return "SerialBattery(" + self.type + ") " + self.address[-5:]
+
+    def unique_identifier(self) -> str:
+        return self.address.replace(":", "").lower()
+
+    def test_connection(self):
+        """
+        Connect, start the notification stream and wait for real data.
+
+        Return True if success, False for failure
+        """
+        result = False
+        try:
+            self.ble_handle = HumsiENK_Syncron_Ble(self.address, read_characteristic=self.BLE_RX_UUID, write_characteristic=self.BLE_TX_UUID)
+
+            if not self.ble_handle.connected:
+                logger.error("HumsiENK_Ble: could not connect to " + self.address)
+                return False
+
+            # The BMS stays silent until the handshake is sent
+            self._send_command(self.CMD_HANDSHAKE)
+            self._last_handshake_time = time.time()
+
+            # Cell voltages carry the cell count, so ask for them first
+            result = self._request(self.CMD_CELL_VOLTAGES, timeout=10.0)
+            result = result and self._request(self.CMD_BATTERY_INFO)
+
+        except Exception:
+            (
+                exception_type,
+                exception_object,
+                exception_traceback,
+            ) = sys.exc_info()
+            file = exception_traceback.tb_frame.f_code.co_filename
+            line = exception_traceback.tb_lineno
+            logger.error(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
+            result = False
+
+        return result
+
+    def get_settings(self):
+        """
+        Capacity, cell count and the charge/discharge limits come from the BMS
+        configuration frame, the firmware version from the version frame.
+
+        Return True if success, False for failure
+        """
+        result = self._request(self.CMD_CONFIG)
+        self._request(self.CMD_VERSION)
+        return result
+
+    def refresh_data(self):
+        """
+        Read everything the BMS has streamed since the last cycle and ask for
+        the next round of data.
+
+        Return True if success, False for failure
+        """
+        try:
+            self._read_frames()
+
+            now = time.time()
+            stale_seconds = now - self._last_frame_time
+
+            if self.ble_handle.connected:
+                # Syncron_Ble reconnects on its own, but the BMS only streams
+                # after a handshake and a single re-send can be lost while the
+                # BMS is still settling, so keep re-sending while starved.
+                if stale_seconds > self.DATA_FRESHNESS_SECONDS and (now - self._last_handshake_time) > self.HANDSHAKE_RETRY_SECONDS:
+                    logger.info(f"HumsiENK: re-sending handshake after {stale_seconds:.0f} s without data")
+                    self._send_command(self.CMD_HANDSHAKE)
+                    self._last_handshake_time = now
+
+                if (now - self._last_poll_time) >= self.POLL_INTERVAL_SECONDS:
+                    self._last_poll_time = now
+                    for command in (self.CMD_BATTERY_INFO, self.CMD_STATUS, self.CMD_CELL_VOLTAGES):
+                        self._send_command(command)
+
+        except Exception as e:
+            logger.warning(f"HumsiENK: refresh_data failed: {repr(e)}")
+
+        # Report only what the radio delivered: values are published as current
+        # or not at all, never republished as if they were fresh.
+        return (time.time() - self._last_frame_time) <= self.DATA_FRESHNESS_SECONDS
+
+    def _build_command(self, command: int, data: list = None) -> bytes:
+        """
+        Build a command frame: [0xAA, CMD, LEN, DATA..., CHK_LO, CHK_HI]
+
+        LEN counts the data bytes only and the checksum is the 16-bit
+        little-endian sum of CMD, LEN and the data bytes.
+
+        :param command: the command code
+        :param data: the data bytes, if the command takes any
+        :return: the encoded frame
+        """
+        data = data if data is not None else []
+        frame = bytearray([self.FRAME_START, command, len(data)])
+        frame.extend(data)
+        checksum = sum(frame[1:]) & 0xFFFF
+        frame.extend([checksum & 0xFF, checksum >> 8])
+        return bytes(frame)
+
+    def _send_command(self, command: int, data: list = None) -> None:
+        """
+        Write a command frame to the BMS.
+
+        Sends fail routinely while the link is being rebuilt, so a failure is
+        logged and the next poll cycle simply tries again.
+
+        :param command: the command code
+        :param data: the data bytes, if the command takes any
+        :return: None
+        """
+        try:
+            self.ble_handle.send_data(self._build_command(command, data))
+        except Exception as e:
+            logger.debug(f"HumsiENK: sending command 0x{command:02X} failed: {repr(e)}")
+
+    def _request(self, command: int, timeout: float = 3.0) -> bool:
+        """
+        Send a command and read frames until its response has been parsed.
+
+        :param command: the command code
+        :param timeout: how long to wait for the response
+        :return: True if the response was parsed, False on timeout
+        """
+        self._send_command(command)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if command in self._read_frames():
+                return True
+        logger.warning(f"HumsiENK: no response to command 0x{command:02X} within {timeout:.0f} s")
+        return False
+
+    def _read_frames(self, timeout: float = 0.3) -> list:
+        """
+        Drain the queued notifications and parse every complete frame in them.
+
+        Response frames use the same layout as commands,
+        [0xAA, CMD, LEN, DATA..., CHK_LO, CHK_HI], but arrive split across
+        notifications, so they are reassembled in a receive buffer. A frame
+        with a bad checksum or an implausible length is resynchronised past
+        by dropping its start byte.
+
+        :param timeout: how long to wait for the first notification
+        :return: the command codes of the frames that were parsed
+        """
+        while True:
+            chunk = self.ble_handle.get_notification(timeout)
+            if chunk is None:
+                break
+            self._rx_buffer.extend(chunk)
+            timeout = 0.0  # only wait for the first chunk, then drain
+
+        commands = []
+        while len(self._rx_buffer) >= 5:
+            start = self._rx_buffer.find(self.FRAME_START)
+            if start == -1:
+                self._rx_buffer.clear()
+                break
+            del self._rx_buffer[:start]
+
+            if len(self._rx_buffer) < 5:
+                break
+
+            data_length = self._rx_buffer[2]
+            if data_length > self.MAX_FRAME_DATA_LENGTH:
+                logger.debug(f"HumsiENK: implausible frame length {data_length}, resyncing")
+                del self._rx_buffer[:1]
+                continue
+
+            total_length = 3 + data_length + 2
+            if len(self._rx_buffer) < total_length:
+                break
+
+            frame = bytes(self._rx_buffer[:total_length])
+            if sum(frame[1:-2]) & 0xFFFF != frame[-2] | (frame[-1] << 8):
+                logger.debug("HumsiENK: checksum mismatch, resyncing")
+                del self._rx_buffer[:1]
+                continue
+
+            del self._rx_buffer[:total_length]
+            self._parse_and_update(frame)
+            self._last_frame_time = time.time()
+            # Fed only here, so the watchdog proves real data, not just a link
+            self.ble_handle.feed_watchdog()
+            commands.append(frame[1])
+
+        return commands
+
+    def _parse_and_update(self, frame: bytes) -> None:
+        """
+        Route a checksum-verified frame to the parser for its command.
+
+        :param frame: the complete frame
+        :return: None
+        """
+        command = frame[1]
+        data = frame[3 : 3 + frame[2]]
+
+        if command == self.CMD_BATTERY_INFO:
+            self._parse_battery_info(data)
+        elif command == self.CMD_CELL_VOLTAGES:
+            self._parse_cell_voltages(data)
+        elif command == self.CMD_STATUS:
+            self._parse_status(data)
+        elif command == self.CMD_CONFIG:
+            self._parse_config(data)
+        elif command == self.CMD_VERSION:
+            self._parse_version(data)
+        else:
+            logger.debug(f"HumsiENK: ignoring response to unknown command 0x{command:02X}")
+
+    def _parse_battery_info(self, data: bytes) -> None:
+        """
+        Parse the 0x21 response (26 bytes).
+
+            voltage (4 bytes): pack voltage in mV
+            current (4 bytes): current in mA, signed
+            soc (1 byte): state of charge in %
+            soh (1 byte): state of health in %
+            capacity (4 bytes): remaining capacity in mAh
+            capacity_total (4 bytes): rated capacity in mAh
+            cycles (2 bytes): charge cycle count
+            t1..t4, mos, environment (1 byte each): temperatures in °C, signed
+
+        The FET states are not in this response, they come from 0x20.
+
+        :param data: the frame payload
+        :return: None
+        """
+        if len(data) < 26:
+            logger.warning(f"HumsiENK: battery info response too short: {len(data)} bytes")
+            return
+
+        self.voltage = int.from_bytes(data[0:4], "little") / 1000
+        self.current = int.from_bytes(data[4:8], "little", signed=True) / 1000
+        self.soc = data[8]
+        self.soh = data[9] if data[9] <= 100 else None
+        self.capacity_remain = int.from_bytes(data[10:14], "little") / 1000
+
+        capacity_total = int.from_bytes(data[14:18], "little") / 1000
+        if capacity_total > 0:
+            self.capacity = capacity_total
+
+        self.history.charge_cycles = int.from_bytes(data[18:20], "little")
+
+        # Temperatures are signed bytes; the environment sensor in data[25] has
+        # no D-Bus path and is not published.
+        for sensor, index in ((1, 20), (2, 21), (3, 22), (4, 23), (0, 24)):
+            self.to_temperature(sensor, data[index] - 256 if data[index] > 127 else data[index])
+
+        logger.debug(
+            f"HumsiENK: {self.voltage:.2f} V, {self.current:.2f} A, {self.soc} %, "
+            f"{self.capacity_remain:.1f}/{self.capacity:.1f} Ah, {self.history.charge_cycles} cycles"
+        )
+
+    def _parse_cell_voltages(self, data: bytes) -> None:
+        """
+        Parse the 0x22 response (up to 48 bytes).
+
+        Up to 24 cell slots of 2 bytes each, in mV. The cells in use are
+        contiguous from the start, so the first slot outside the plausible
+        range marks the end of the string.
+
+        :param data: the frame payload
+        :return: None
+        """
+        millivolts = [int.from_bytes(data[i : i + 2], "little") for i in range(0, min(len(data), 48) - 1, 2)]
+
+        cell_count = 0
+        for millivolt in millivolts:
+            if not 1000 <= millivolt <= 5000:
+                break
+            cell_count += 1
+
+        if cell_count == 0:
+            logger.debug("HumsiENK: cell voltage response contains no plausible cells")
+            return
+
+        if cell_count != self.cell_count:
+            logger.info(f"HumsiENK: detected {cell_count} cells (was {self.cell_count})")
+            self.cell_count = cell_count
+
+        while len(self.cells) < cell_count:
+            self.cells.append(Cell(False))
+        del self.cells[cell_count:]
+
+        for index in range(cell_count):
+            self.cells[index].voltage = millivolts[index] / 1000
+
+        # self.voltage is deliberately left alone: the pack voltage reported by
+        # 0x21 is more accurate than the sum of the rounded cell voltages.
+
+    def _parse_status(self, data: bytes) -> None:
+        """
+        Parse the 0x20 response (14 bytes).
+
+            bytes 0-3: runtime (days: 2, hours: 1, minutes: 1), not published
+            bytes 4-7: operation status flags (32 bit, see below)
+            bytes 8-10: cell balancing bitmap (24 bit)
+            bytes 11-13: cell disconnect bitmap (24 bit)
+
+        Operation status flags, charge section:
+
+            bit 0: charge overcurrent protection
+            bit 1: charge over-temperature protection
+            bit 2: charge under-temperature protection
+            bit 4: pack overvoltage protection
+            bit 7: charge FET state (1 = on)
+            bit 8: charge overcurrent warning
+            bit 9: charge over-temperature warning
+            bit 10: charge under-temperature warning
+            bit 12: pack overvoltage warning
+            bit 15: balancing active
+
+        Discharge section:
+
+            bit 16: discharge overcurrent protection
+            bit 17: discharge over-temperature protection
+            bit 18: discharge under-temperature protection
+            bit 20: short circuit protection
+            bit 21: pack undervoltage protection
+            bit 23: discharge FET state (1 = on)
+            bit 24: discharge overcurrent warning
+            bit 25: discharge over-temperature warning
+            bit 26: discharge under-temperature warning
+            bit 28: pack undervoltage warning
+            bit 29: MOSFET over-temperature warning
+            bit 30: MOSFET over-temperature protection
+
+        :param data: the frame payload
+        :return: None
+        """
+        if len(data) < 14:
+            logger.warning(f"HumsiENK: status response too short: {len(data)} bytes")
+            return
+
+        status = int.from_bytes(data[4:8], "little")
+
+        def alarm(protection_bit: int, warning_bit: int = None) -> int:
+            """Map a protection/warning bit pair to 0 (ok), 1 (warning) or 2 (alarm)."""
+            if status & (1 << protection_bit):
+                return 2
+            if warning_bit is not None and status & (1 << warning_bit):
+                return 1
+            return 0
+
+        self.charge_fet = bool(status & (1 << 7))
+        self.discharge_fet = bool(status & (1 << 23))
+        self.balance_fet = bool(status & (1 << 15))
+
+        self.protection.high_voltage = alarm(4, 12)
+        self.protection.low_voltage = alarm(21, 28)
+        self.protection.high_charge_current = alarm(0, 8)
+        self.protection.high_charge_temperature = alarm(1, 9)
+        self.protection.low_charge_temperature = alarm(2, 10)
+        self.protection.high_temperature = alarm(17, 25)
+        self.protection.low_temperature = alarm(18, 26)
+        self.protection.high_internal_temperature = alarm(30, 29)  # MOSFET
+
+        # A short circuit trips the same discharge path and has no D-Bus alarm
+        # of its own, so it is reported as a discharge overcurrent.
+        self.protection.high_discharge_current = 2 if status & (1 << 20) else alarm(16, 24)
+
+        balancing = int.from_bytes(data[8:11], "little")
+        for index in range(min(len(self.cells), 24)):
+            self.cells[index].balance = bool(balancing & (1 << index))
+
+        # A set disconnect bit means a cell is physically disconnected, which is
+        # a wiring fault rather than a battery condition. The vendor app reads
+        # this field but never shows it.
+        disconnected = int.from_bytes(data[11:14], "little")
+        self.protection.internal_failure = 2 if disconnected else 0
+        if disconnected:
+            cells = [index + 1 for index in range(min(len(self.cells), 24)) if disconnected & (1 << index)]
+            logger.error(f"HumsiENK: cells reported as disconnected: {cells}")
+
+        logger.debug(f"HumsiENK: charge FET {self.charge_fet}, discharge FET {self.discharge_fet}, balancing {self.balance_fet}")
+
+    def _parse_config(self, data: bytes) -> None:
+        """
+        Parse the 0x58 response (44 bytes).
+
+        22 little-endian 16-bit values: cell count, rated capacity in 0.01 Ah,
+        then the protection thresholds with their recovery points and delays —
+        cell overvoltage and undervoltage in mV, charge and discharge
+        overcurrent in 0.1 A, and the temperature limits in deciKelvin.
+
+        :param data: the frame payload
+        :return: None
+        """
+        if len(data) < 44:
+            logger.warning(f"HumsiENK: config response too short: {len(data)} bytes")
+            return
+
+        values = [int.from_bytes(data[i : i + 2], "little") for i in range(0, 44, 2)]
+        cell_count = values[0]
+        capacity = values[1] / 100
+        cell_max_voltage = values[2] / 1000
+        cell_min_voltage = values[5] / 1000
+        max_charge_current = values[8] / 10
+        max_discharge_current = values[10] / 10
+        # Vendor scaling for the temperature limits: (raw - 2731) / 10 -> °C
+        charge_temp_max = (values[14] - 2731) / 10
+        charge_temp_min = (values[16] - 2731) / 10
+        discharge_temp_max = (values[18] - 2731) / 10
+        discharge_temp_min = (values[20] - 2731) / 10
+
+        if 0 < cell_count <= 24:
+            self.cell_count = cell_count
+        if capacity > 0:
+            self.capacity = capacity
+        if cell_max_voltage > 0 and cell_count > 0:
+            self.max_battery_voltage = cell_max_voltage * cell_count
+        if cell_min_voltage > 0 and cell_count > 0:
+            self.min_battery_voltage = cell_min_voltage * cell_count
+        if max_charge_current > 0:
+            self.max_battery_charge_current = max_charge_current
+        if max_discharge_current > 0:
+            self.max_battery_discharge_current = max_discharge_current
+
+        logger.info(
+            f"HumsiENK: config {cell_count}S {capacity} Ah, "
+            f"cell {cell_min_voltage}-{cell_max_voltage} V, "
+            f"charge {max_charge_current} A at {charge_temp_min}-{charge_temp_max} °C, "
+            f"discharge {max_discharge_current} A at {discharge_temp_min}-{discharge_temp_max} °C"
+        )
+
+    def _parse_version(self, data: bytes) -> None:
+        """
+        Parse the 0xF5 response, an ASCII firmware version string.
+
+        :param data: the frame payload
+        :return: None
+        """
+        version = "".join(chr(byte) for byte in data if 32 <= byte <= 126)
+        if version:
+            self.hardware_version = f"HumsiENK v{version}"
+            logger.info(f"HumsiENK: firmware version {version}")
+        else:
+            logger.warning(f"HumsiENK: could not decode the firmware version from {data.hex()}")

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -146,6 +146,18 @@ BLUETOOTH_FORCE_RESET_BLE_STACK = False
 ;     BleakBackend: Connect directly with bleak
 BLUETOOTH_CONNECTION_BACKEND = BleakBackend
 
+; Bluetooth adapters (hciX) to use for BLE BMS connections.
+; Connections are made only via the listed adapters, in order, rotating to
+; the next entry after a failed connection attempt.
+; Empty = use the system default adapter.
+; Useful on GX devices with multiple Bluetooth adapters where the default
+; adapter is heavily used by other services: scan contention can make
+; connections fail with org.bluez.Error.InProgress, and a misbehaving
+; controller drops every BLE connection on that adapter at once.
+; Example:
+;     BLUETOOTH_ADAPTERS = hci1, hci2
+BLUETOOTH_ADAPTERS =
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -125,7 +125,7 @@ CURRENT_MEASURED_BY_USER = -300, 300
 ; Description:
 ;     Specify the Bluetooth BMS and its MAC address that you want to use. Leave empty to disable.
 ; Available Bluetooth BMS:
-;     Jkbms_Ble, Kilovault_Ble, LiTime_Ble, LltJbd_Ble, Xdzn_Ble
+;     HumsiENK_Ble, Jkbms_Ble, Kilovault_Ble, LiTime_Ble, LltJbd_Ble, Xdzn_Ble
 ; Example for one BMS:
 ;     BLUETOOTH_BMS = Jkbms_Ble C8:47:8C:00:00:00
 ; Example for multiple BMS:
@@ -550,7 +550,7 @@ HISTORY_ENABLE = True
 ;     Daly_Can, Jkbms_Can, LltJbd_Can, RV_C_Can, Ubms_Can
 ;
 ; Available Bluetooth BMS:
-;     Jkbms_Ble, Kilovault_Ble, LiTime_Ble, LltJbd_Ble, Xdzn_Ble
+;     HumsiENK_Ble, Jkbms_Ble, Kilovault_Ble, LiTime_Ble, LltJbd_Ble, Xdzn_Ble
 BMS_TYPE =
 
 ; Exclude these serial devices from the driver startup.

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -141,6 +141,11 @@ BLUETOOTH_USE_POLLING = True
 ; Try to reset the BLE stack if the connection is lost or a crash is detected.
 BLUETOOTH_FORCE_RESET_BLE_STACK = False
 
+; Backend used to establish Bluetooth LE connections.
+; Available backends:
+;     BleakBackend: Connect directly with bleak
+BLUETOOTH_CONNECTION_BACKEND = BleakBackend
+
 
 ; --------- Bluetooth use USB ---------
 ; +++ Works only on Raspberry Pi devices. +++

--- a/dbus-serialbattery/dbus-serialbattery.py
+++ b/dbus-serialbattery/dbus-serialbattery.py
@@ -409,7 +409,11 @@ def main():
         else:
             ble_address = sys.argv[2]
 
-            if port == "Jkbms_Ble":
+            if port == "HumsiENK_Ble":
+                # noqa: F401 --> ignore flake "imported but unused" error
+                from bms.humsienk_ble import HumsiENK_Ble  # noqa: F401
+
+            elif port == "Jkbms_Ble":
                 # noqa: F401 --> ignore flake "imported but unused" error
                 from bms.jkbms_ble import Jkbms_Ble  # noqa: F401
 
@@ -431,7 +435,7 @@ def main():
 
             else:
                 logger.error(">>> Unknown Bluetooth BMS type: " + port)
-                logger.error("Supported Bluetooth BMS types (CASE SENSITIVE!): Jkbms_Ble, Kilovault_Ble, LiTime_Ble, LltJbd_Ble, Xdzn_Ble")
+                logger.error("Supported Bluetooth BMS types (CASE SENSITIVE!): HumsiENK_Ble, Jkbms_Ble, Kilovault_Ble, LiTime_Ble, LltJbd_Ble, Xdzn_Ble")
                 sleep(60)
                 exit_driver(None, None, 1)
 

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -261,6 +261,7 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 # --------- Bluetooth BMS ---------
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
+BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -262,6 +262,9 @@ CURRENT_CORRECTION: bool = CURRENT_REPORTED_BY_BMS != CURRENT_MEASURED_BY_USER
 BLUETOOTH_USE_POLLING = get_bool_from_config("DEFAULT", "BLUETOOTH_USE_POLLING")
 BLUETOOTH_FORCE_RESET_BLE_STACK = get_bool_from_config("DEFAULT", "BLUETOOTH_FORCE_RESET_BLE_STACK")
 BLUETOOTH_CONNECTION_BACKEND: str = config["DEFAULT"]["BLUETOOTH_CONNECTION_BACKEND"].strip()
+# Bluetooth adapters (hciX) to use for BLE BMS connections, tried in order.
+# Empty list = use the system default adapter.
+BLUETOOTH_ADAPTERS: List[str] = get_list_from_config("DEFAULT", "BLUETOOTH_ADAPTERS", str)
 
 # --------- Daisy Chain Configuration (Multiple BMS on one cable) ---------
 BATTERY_ADDRESSES: list = get_list_from_config("DEFAULT", "BATTERY_ADDRESSES", str)

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -5,7 +5,84 @@ import sys
 from bleak import BleakClient
 from bleak.exc import BleakCharacteristicNotFoundError
 from time import sleep
-from utils import logger, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+
+
+class BleConnectionBackend:
+    """
+    Interface for establishing and releasing BLE connections.
+
+    Separates how a connection is established/torn down (the backend) from how
+    Syncron_Ble supervises it and exchanges data with the BMS drivers. This allows
+    alternative connection strategies to be plugged in without touching the drivers.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        """
+        Create the BleakClient for the given address, or None if the backend
+        creates its own client during establish().
+        """
+        raise NotImplementedError
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        """
+        Connect and start notifications. Returns the connected client
+        (may differ from the one passed in). Raises on failure.
+        """
+        raise NotImplementedError
+
+    async def release(self, client):
+        """Disconnect the client."""
+        raise NotImplementedError
+
+
+class BleakBackend(BleConnectionBackend):
+    """
+    Default backend: connects directly with bleak, matching the historical
+    behavior of this driver.
+    """
+
+    def create_client(self, address, disconnected_callback):
+        return BleakClient(address, disconnected_callback=disconnected_callback)
+
+    async def establish(self, client, address, notify_char, notify_callback):
+        logger.info("initiating BLE connection to: " + address)
+        await client.connect()
+        logger.info("connected to bluetooh device" + address)
+        # On some devices GATT characteristics become available only after connect()
+        # has already returned, so the first start_notify() can raise
+        # BleakCharacteristicNotFoundError for a characteristic that does exist.
+        # Re-run service discovery and retry before giving up.
+        for attempt in range(3):
+            try:
+                await client.start_notify(notify_char, notify_callback)
+                break
+            except BleakCharacteristicNotFoundError:
+                if attempt == 2:
+                    raise
+                logger.warning(f"characteristic {notify_char} not found yet, re-running service discovery")
+                # bleak has no public API to re-run service discovery on a connected
+                # client; clear the cached services so _get_services() fetches again
+                client._backend.services = None
+                await client._backend._get_services()
+                await asyncio.sleep(0.5)
+        return client
+
+    async def release(self, client):
+        await client.disconnect()
+
+
+# Available connection backends, selected by class name via BLUETOOTH_CONNECTION_BACKEND
+supported_ble_backends = [BleakBackend]
+
+
+def get_ble_backend():
+    """Return the connection backend selected by BLUETOOTH_CONNECTION_BACKEND."""
+    for backend in supported_ble_backends:
+        if backend.__name__ == BLUETOOTH_CONNECTION_BACKEND:
+            return backend()
+    logger.warning(f"Unknown BLUETOOTH_CONNECTION_BACKEND '{BLUETOOTH_CONNECTION_BACKEND}', using 'BleakBackend'")
+    return BleakBackend()
 
 
 # Class that enables synchronous writing and reading to a bluetooh device
@@ -35,6 +112,7 @@ class Syncron_Ble:
         self.write_characteristic = write_characteristic
         self.read_characteristic = read_characteristic
         self.address = address
+        self.backend = get_ble_backend()
 
         # Start a new thread that will run bleak the async bluetooth LE library
         self.main_thread = threading.current_thread()
@@ -66,37 +144,19 @@ class Syncron_Ble:
         logger.error(f"bluetooh device with address: {self.address} disconnected")
 
     async def connect_to_bms(self, address):
-        self.client = BleakClient(address, disconnected_callback=self.client_disconnected)
+        self.client = self.backend.create_client(address, self.client_disconnected)
         try:
-            logger.info("initiating BLE connection to: " + address)
-            await self.client.connect()
-            logger.info("connected to bluetooh device" + address)
-            # On some devices GATT characteristics become available only after connect()
-            # has already returned, so the first start_notify() can raise
-            # BleakCharacteristicNotFoundError for a characteristic that does exist.
-            # Re-run service discovery and retry before giving up.
-            for attempt in range(3):
-                try:
-                    await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
-                    break
-                except BleakCharacteristicNotFoundError:
-                    if attempt == 2:
-                        raise
-                    logger.warning(f"characteristic {self.read_characteristic} not found yet, re-running service discovery")
-                    # bleak has no public API to re-run service discovery on a connected
-                    # client; clear the cached services so _get_services() fetches again
-                    self.client._backend.services = None
-                    await self.client._backend._get_services()
-                    await asyncio.sleep(0.5)
+            self.client = await self.backend.establish(self.client, address, self.read_characteristic, self.notify_read_callback)
 
         except Exception as e:
             logger.error("Failed when trying to connect", e)
             return False
         finally:
             self.ble_connection_ready.set()
-            while self.client.is_connected and self.main_thread.is_alive():
-                await asyncio.sleep(0.1)
-            await self.client.disconnect()
+            if self.client:
+                while self.client.is_connected and self.main_thread.is_alive():
+                    await asyncio.sleep(0.1)
+                await self.backend.release(self.client)
 
     # saves response and tells the command sender that the response has arived
     def notify_read_callback(self, sender, data: bytearray):

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -113,14 +113,18 @@ class Syncron_Ble:
         self.response_event = False
         return self.response_data
 
-    async def send_coroutine_to_ble_thread_and_wait_for_result(self, coroutine):
-        bt_task = asyncio.run_coroutine_threadsafe(coroutine, self.ble_async_thread_event_loop)
-        result = await asyncio.wait_for(asyncio.wrap_future(bt_task), timeout=1.5)
-        return result
-
     def send_data(self, data):
-        data = asyncio.run(self.send_coroutine_to_ble_thread_and_wait_for_result(self.ble_thread_send_com(data)))
-        return data
+        # Schedule the write on the BLE thread's existing event loop and wait
+        # for the result directly. The previous implementation wrapped this in
+        # asyncio.run(), constructing and tearing down a whole event loop for
+        # every command sent — measurable CPU overhead on GX hardware for
+        # drivers that poll several commands every few seconds.
+        future = asyncio.run_coroutine_threadsafe(self.ble_thread_send_com(data), self.ble_async_thread_event_loop)
+        try:
+            return future.result(timeout=1.5)
+        except Exception:
+            future.cancel()
+            raise
 
 
 def restart_ble_hardware_and_bluez_driver():

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -5,7 +5,7 @@ import sys
 from bleak import BleakClient
 from bleak.exc import BleakCharacteristicNotFoundError
 from time import sleep
-from utils import logger, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
+from utils import logger, BLUETOOTH_ADAPTERS, BLUETOOTH_CONNECTION_BACKEND, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
 
 
 class BleConnectionBackend:
@@ -40,32 +40,50 @@ class BleakBackend(BleConnectionBackend):
     """
     Default backend: connects directly with bleak, matching the historical
     behavior of this driver.
+
+    If BLUETOOTH_ADAPTERS is set, connections are made only via the listed
+    adapters, rotating to the next entry after a failed attempt. An empty
+    list uses the system default adapter.
     """
 
+    def __init__(self):
+        self.adapter_index = 0
+        self.current_adapter = None
+
     def create_client(self, address, disconnected_callback):
-        return BleakClient(address, disconnected_callback=disconnected_callback)
+        kwargs = {}
+        if BLUETOOTH_ADAPTERS:
+            self.current_adapter = BLUETOOTH_ADAPTERS[self.adapter_index % len(BLUETOOTH_ADAPTERS)]
+            kwargs["adapter"] = self.current_adapter
+        return BleakClient(address, disconnected_callback=disconnected_callback, **kwargs)
 
     async def establish(self, client, address, notify_char, notify_callback):
-        logger.info("initiating BLE connection to: " + address)
-        await client.connect()
-        logger.info("connected to bluetooh device" + address)
-        # On some devices GATT characteristics become available only after connect()
-        # has already returned, so the first start_notify() can raise
-        # BleakCharacteristicNotFoundError for a characteristic that does exist.
-        # Re-run service discovery and retry before giving up.
-        for attempt in range(3):
-            try:
-                await client.start_notify(notify_char, notify_callback)
-                break
-            except BleakCharacteristicNotFoundError:
-                if attempt == 2:
-                    raise
-                logger.warning(f"characteristic {notify_char} not found yet, re-running service discovery")
-                # bleak has no public API to re-run service discovery on a connected
-                # client; clear the cached services so _get_services() fetches again
-                client._backend.services = None
-                await client._backend._get_services()
-                await asyncio.sleep(0.5)
+        logger.info("initiating BLE connection to: " + address + (f" (adapter {self.current_adapter})" if self.current_adapter else ""))
+        try:
+            await client.connect()
+            logger.info("connected to bluetooh device" + address)
+            # On some devices GATT characteristics become available only after connect()
+            # has already returned, so the first start_notify() can raise
+            # BleakCharacteristicNotFoundError for a characteristic that does exist.
+            # Re-run service discovery and retry before giving up.
+            for attempt in range(3):
+                try:
+                    await client.start_notify(notify_char, notify_callback)
+                    break
+                except BleakCharacteristicNotFoundError:
+                    if attempt == 2:
+                        raise
+                    logger.warning(f"characteristic {notify_char} not found yet, re-running service discovery")
+                    # bleak has no public API to re-run service discovery on a connected
+                    # client; clear the cached services so _get_services() fetches again
+                    client._backend.services = None
+                    await client._backend._get_services()
+                    await asyncio.sleep(0.5)
+        except Exception:
+            # rotate to the next configured adapter for the next attempt
+            if BLUETOOTH_ADAPTERS:
+                self.adapter_index += 1
+            raise
         return client
 
     async def release(self, client):

--- a/dbus-serialbattery/utils_ble.py
+++ b/dbus-serialbattery/utils_ble.py
@@ -3,6 +3,7 @@ import asyncio
 import subprocess
 import sys
 from bleak import BleakClient
+from bleak.exc import BleakCharacteristicNotFoundError
 from time import sleep
 from utils import logger, BLUETOOTH_FORCE_RESET_BLE_STACK, capture_raw_data
 
@@ -70,7 +71,23 @@ class Syncron_Ble:
             logger.info("initiating BLE connection to: " + address)
             await self.client.connect()
             logger.info("connected to bluetooh device" + address)
-            await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
+            # On some devices GATT characteristics become available only after connect()
+            # has already returned, so the first start_notify() can raise
+            # BleakCharacteristicNotFoundError for a characteristic that does exist.
+            # Re-run service discovery and retry before giving up.
+            for attempt in range(3):
+                try:
+                    await self.client.start_notify(self.read_characteristic, self.notify_read_callback)
+                    break
+                except BleakCharacteristicNotFoundError:
+                    if attempt == 2:
+                        raise
+                    logger.warning(f"characteristic {self.read_characteristic} not found yet, re-running service discovery")
+                    # bleak has no public API to re-run service discovery on a connected
+                    # client; clear the cached services so _get_services() fetches again
+                    self.client._backend.services = None
+                    await self.client._backend._get_services()
+                    await asyncio.sleep(0.5)
 
         except Exception as e:
             logger.error("Failed when trying to connect", e)


### PR DESCRIPTION
> **Draft note:** continuing the soak on my Cerbo before marking ready. This PR supersedes #501 with a rewritten, simplified driver. Same stack, same protocol decoding; the driver itself is much smaller and no longer does anything unusual for a BMS driver in this repo.

## What

Adds a standalone driver for HumsiENK BLE batteries (`HumsiENK_Ble`).

**Stacked PR — review the last commit.** The earlier commits are shared BLE infrastructure submitted separately; they are included here so this branch is self-contained and mergeable in any order:

| Commit | Belongs to |
|---|---|
| `Retry start_notify when characteristic is not yet resolved` | #493 |
| `Drop per-command event loop in Syncron_Ble.send_data` | #493 |
| `Extract BLE connection backend seam from Syncron_Ble` | connection-backend seam (PR to follow) |
| `Add BLUETOOTH_ADAPTERS to restrict BLE connections` | #497 |
| **`Add HumsiENK BLE battery driver`** | **this PR** |

When the shared PRs merge, a rebase reduces this to the driver commit alone.

The wire protocol is documented in the aiobmsble project:
- https://github.com/patman15/aiobmsble/blob/main/docs/humsienk_bms.md
- https://github.com/patman15/aiobmsble/blob/main/aiobmsble/bms/humsienk_bms.py

## What changed since #501

#501's driver carried machinery that no other driver in this repo has, and that I no longer think a driver should have. All of it is gone:

- **No stale-data serving.** #501 had an escalating alarm ladder that kept republishing the last known values, for up to 30 minutes, while the link was down. The driver now reports only what the radio actually delivered.
- **No fabricated values.** #501 seeded 3.4 V per cell, 50 % SOC and a pack voltage at startup, and normalised unread cells to 0.0 V. Those numbers reached D-Bus as if they were measurements. There are now no seeds at all.
- **No persistence.** #501 kept a JSON state file under `/data/` and restored from it on boot. Nothing is written to disk.
- **Registration only on real data.** `test_connection()` connects, sends the vendor handshake that starts the notification stream, and returns True only once real cell voltages and pack values have been parsed — the same shape as the other BLE drivers. Because registration cannot happen before measured data exists, the seeds and the state file had nothing left to do.
- **Honest refresh verdict.** `refresh_data()` returns success only while a checksum-verified frame has arrived in the last 15 s, so a live link with a dead stream is reported as the failure it is, and the framework's normal error counting and retry handling engages. `Jkbms_Ble` reports stale data on the same threshold.

The driver file went from 1377 to 614 lines, most of the remainder being the protocol register maps. Also fixed along the way: several `self.protection.*` fields that #501 set under names that do not exist on `Protection` (`high_charge_temp`, `low_charge_temp`, `high_discharge_temp`, `low_discharge_temp`, `short_circuit`), so those alarms were silently never published; and cycle count now goes to `self.history.charge_cycles` rather than an attribute nothing reads.

## Driver-local BLE subclass

The one structure without a direct sibling analogue is the small `Syncron_Ble` subclass, and it is there because of the protocol rather than for robustness. `Syncron_Ble` is built for request/response BMS and keeps a single response slot that the next notification overwrites. This BMS streams frames continuously once handshaked, and one logical frame regularly spans several notifications, so the subclass adds a notification queue, live `connected` tracking, and a watchdog that drops a link whose stream has died — since unsolicited notifications mean "link up" and "data flowing" are independent states. (`Jkbms_Ble` handles the same failure mode by resetting the BLE stack after 30 s without data.)

## Relationship to the aiobmsble path (#449)

The same protocol was contributed to aiobmsble in parallel. This standalone driver exists because of three gaps in the generic path today (details in #449): no protections/alarms mapping in `generic_aiobmsble.py`, no BMS-config-derived charge parameters, and approximate balance display. If the generic path closes those gaps, this driver can be deprecated in its favor.

## Testing

Validated against two production HumsiENK HS03 packs (4-cell LiFePO4, 628 Ah each) on a Cerbo GX MK2, Venus OS v3.73, across multi-day live operation:

- Live pack/cell values, temperatures, BMS-reported capacity, correct CVL taper, alarms clear/raise correctly
- Disconnect recovery across many organic BLE dropouts (the test environment has four BT adapters shared with other scanning services — an aggressive stress environment)
- Late-connect and lost-handshake recovery (periodic handshake retry while data-starved)
- Sustained CPU measured at 2.7 % per driver instance on the Cerbo after the event-driven queue and `send_data` fixes

The frame codec and all five parsers were additionally exercised off-device against synthetic frames, covering reassembly across notification boundaries, checksum rejection with resync, truncated and implausible-length frames, signed temperatures, and the alarm bit mapping. `flake8` and `black` are clean; `pytest tests` shows no change from the base commit.

Environmental disclosure: the test device carries a local patch suppressing the venus#1587 60 s BLE disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
