### PR TITLE
Add external sensor override for voltage and temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Added: dbus caching to reduce writes and therefore CPU consumption with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/397 by @cgoudie
 * Added: Device state and mode values by @mr-manuel
 * Added: Disable serial starter if not needed by @mr-manuel
+* Added: `EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE` and `EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE` to read the published battery voltage and temperature from an external sensor, e.g. a SmartShunt, extending the existing `EXTERNAL_SENSOR_DBUS_PATH_CURRENT` and `EXTERNAL_SENSOR_DBUS_PATH_SOC` options. The external voltage is also used for the power calculation, so voltage, current and power come from the same instrument. If the external sensor is unavailable, the BMS values are used by @cgoudie
 * Added: Generic MQTT BMS by @mr-manuel
 * Added: Health check for batteries which are using the callback by @mr-manuel
 * Added: JBD CAN protocol support with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/363 by @dmitrych5

--- a/dbus-serialbattery/battery.py
+++ b/dbus-serialbattery/battery.py
@@ -437,6 +437,7 @@ class Battery(ABC):
         :return: None
         """
         self.voltage: float = None
+        self.voltage_calc: float = None
         self.current: float = None
         self.current_calc: float = None
         self.current_corrected: float = None
@@ -2014,6 +2015,12 @@ class Battery(ABC):
         return {sensor: temperature_map[sensor] for sensor in utils.TEMPERATURE_SOURCE_BATTERY if temperature_map.get(sensor) is not None}
 
     def get_temperature(self) -> Union[float, None]:
+        # get external sensor value
+        if self.dbus_external_objects is not None and "Temperature" in self.dbus_external_objects and self.dbus_external_objects["Temperature"] is not None:
+            temperature_external = self.dbus_external_objects["Temperature"].get_value()
+            if temperature_external is not None:
+                return round(temperature_external, 1)
+
         try:
             temperature_map = self.get_filtered_temperature_map()
 
@@ -2126,6 +2133,14 @@ class Battery(ABC):
 
             if is_present_in_vebus:
 
+                if utils.EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE is not None:
+                    logger.info(f"Using external sensor for voltage: {utils.EXTERNAL_SENSOR_DBUS_DEVICE}{utils.EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE}")
+                    dbus_objects["Voltage"] = VeDbusItemImport(
+                        dbus_connection,
+                        utils.EXTERNAL_SENSOR_DBUS_DEVICE,
+                        utils.EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE,
+                    )
+
                 if utils.EXTERNAL_SENSOR_DBUS_PATH_CURRENT is not None:
                     logger.info(f"Using external sensor for current: {utils.EXTERNAL_SENSOR_DBUS_DEVICE}{utils.EXTERNAL_SENSOR_DBUS_PATH_CURRENT}")
                     dbus_objects["Current"] = VeDbusItemImport(
@@ -2142,13 +2157,23 @@ class Battery(ABC):
                         utils.EXTERNAL_SENSOR_DBUS_PATH_SOC,
                     )
 
+                if utils.EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE is not None:
+                    logger.info(f"Using external sensor for temperature: {utils.EXTERNAL_SENSOR_DBUS_DEVICE}{utils.EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE}")
+                    dbus_objects["Temperature"] = VeDbusItemImport(
+                        dbus_connection,
+                        utils.EXTERNAL_SENSOR_DBUS_DEVICE,
+                        utils.EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE,
+                    )
+
                 self.dbus_external_objects = dbus_objects
 
         except Exception:
             # set to None to avoid crashing, fallback to battery current
             utils.EXTERNAL_SENSOR_DBUS_DEVICE = None
+            utils.EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE = None
             utils.EXTERNAL_SENSOR_DBUS_PATH_CURRENT = None
             utils.EXTERNAL_SENSOR_DBUS_PATH_SOC = None
+            utils.EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE = None
             self.dbus_external_objects = None
             (
                 exception_type,
@@ -2159,6 +2184,24 @@ class Battery(ABC):
             line = exception_traceback.tb_lineno
             logger.error(f"Exception occurred: {repr(exception_object)} of type {exception_type} in {file} line #{line}")
             logger.error("External current sensor setup failed, fallback to internal sensor")
+
+    def get_voltage(self) -> Union[float, None]:
+        """
+        Get the voltage, either from:
+        - the external sensor
+        - the battery
+
+        :return: The voltage
+        """
+        # get external sensor value
+        if self.dbus_external_objects is not None and "Voltage" in self.dbus_external_objects and self.dbus_external_objects["Voltage"] is not None:
+            voltage_external = self.dbus_external_objects["Voltage"].get_value()
+            logger.debug(f"voltage: {self.voltage} - voltage_external: {voltage_external}")
+            if voltage_external is not None:
+                return round(voltage_external, 3)
+
+        # fall back to the value from the battery
+        return self.voltage
 
     def get_current(self) -> Union[float, None]:
         """
@@ -2236,7 +2279,7 @@ class Battery(ABC):
             # Coloumb count discharged energy
             self.energy_discharged += energy * -1 if energy < 0 else 0
 
-        power = self.voltage * self.current_calc if self.current_calc is not None and self.voltage is not None else None
+        power = self.voltage_calc * self.current_calc if self.current_calc is not None and self.voltage_calc is not None else None
 
         self.power_calc_last_time = current_time
         return power
@@ -2268,6 +2311,7 @@ class Battery(ABC):
 
         :return: None
         """
+        self.voltage_calc = self.get_voltage()
         self.current_calc = self.get_current()
         self.power_calc = self.get_power()
         self.soc_calc = self.get_soc()

--- a/dbus-serialbattery/config.default.ini
+++ b/dbus-serialbattery/config.default.ini
@@ -216,18 +216,29 @@ BLOCK_ON_DISCONNECT_VOLTAGE_MAX = 3.375
 BMS_CABLE_ALARM = True
 
 
-; --------- External Sensor for Current and/or SoC ---------
+; --------- External Sensor for Voltage, Current, SoC and/or Temperature ---------
 ; Description:
-;     Specify the dbus device where the external sensor is connected. Then specify the path to the current and/or SoC value.
+;     Specify the dbus device where the external sensor is connected. Then specify the path to the voltage, current, SoC
+;     and/or temperature value.
 ;     You can find this information by executing the dbus-spy command.
+;     Useful when an external sensor, e.g. a SmartShunt, measures more precisely than the BMS. Many BMS round the current to
+;     whole amps and measure the voltage internally, while a shunt measures with sub-amp/millivolt precision at the battery
+;     terminals. The external values replace the BMS values published on /Dc/0/Voltage, /Dc/0/Current and /Dc/0/Temperature
+;     and are used for the power calculation. If the external sensor is unavailable, the driver falls back to the BMS values.
+;     The external temperature only replaces the published battery temperature. Temperature based charge/discharge limits
+;     still use the BMS cell temperature sensors.
 ;     EXTERNAL_SENSOR_DBUS_PATH_SOC does not work with SOC_CALCULATION enabled.
-; Example for a SmartShunt as external current sensor:
+; Example for a SmartShunt as external voltage, current and temperature sensor:
 ;     EXTERNAL_SENSOR_DBUS_DEVICE = com.victronenergy.battery.ttyS2
+;     EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE = /Dc/0/Voltage
 ;     EXTERNAL_SENSOR_DBUS_PATH_CURRENT = /Dc/0/Current
 ;     EXTERNAL_SENSOR_DBUS_PATH_SOC = /Soc
+;     EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE = /Dc/0/Temperature
 EXTERNAL_SENSOR_DBUS_DEVICE =
+EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE =
 EXTERNAL_SENSOR_DBUS_PATH_CURRENT =
 EXTERNAL_SENSOR_DBUS_PATH_SOC =
+EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE =
 
 
 ; --------- Charge Mode ---------

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -944,7 +944,10 @@ class DbusHelper:
 
             # Check if external sensor is still connected
             if utils.EXTERNAL_SENSOR_DBUS_DEVICE is not None and (
-                utils.EXTERNAL_SENSOR_DBUS_PATH_CURRENT is not None or utils.EXTERNAL_SENSOR_DBUS_PATH_SOC is not None
+                utils.EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE is not None
+                or utils.EXTERNAL_SENSOR_DBUS_PATH_CURRENT is not None
+                or utils.EXTERNAL_SENSOR_DBUS_PATH_SOC is not None
+                or utils.EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE is not None
             ):
                 # Check if external sensor was and is still connected
                 if self.battery.dbus_external_objects is not None and utils.EXTERNAL_SENSOR_DBUS_DEVICE not in get_bus(self._dbusname).list_names():
@@ -1137,7 +1140,7 @@ class DbusHelper:
         else:
             self._dbusservice["/Soc"] = round(self.battery.soc_calc, 2) if self.battery.soc is not None else None
         self._dbusservice["/Soh"] = round(self.battery.soh, 2) if self.battery.soh is not None else None
-        self._dbusservice["/Dc/0/Voltage"] = round(self.battery.voltage, 2) if self.battery.voltage is not None else None
+        self._dbusservice["/Dc/0/Voltage"] = round(self.battery.voltage_calc, 2) if self.battery.voltage_calc is not None else None
         self._dbusservice["/Dc/0/Current"] = round(self.battery.current_calc, 2) if self.battery.current_calc is not None else None
         self._dbusservice["/Dc/0/Power"] = round(self.battery.power_calc, 2) if self.battery.power_calc is not None else None
         self._dbusservice["/Dc/0/Temperature"] = self.battery.get_temperature()

--- a/dbus-serialbattery/utils.py
+++ b/dbus-serialbattery/utils.py
@@ -303,10 +303,12 @@ if not BLOCK_ON_DISCONNECT:
 BMS_CABLE_ALARM: bool = get_bool_from_config("DEFAULT", "BMS_CABLE_ALARM")
 
 
-# --------- External Sensor for Current and/or SoC ---------
+# --------- External Sensor for Voltage, Current, SoC and/or Temperature ---------
 EXTERNAL_SENSOR_DBUS_DEVICE: Union[str, None] = config["DEFAULT"]["EXTERNAL_SENSOR_DBUS_DEVICE"] or None
+EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE: Union[str, None] = config["DEFAULT"]["EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE"] or None
 EXTERNAL_SENSOR_DBUS_PATH_CURRENT: Union[str, None] = config["DEFAULT"]["EXTERNAL_SENSOR_DBUS_PATH_CURRENT"] or None
 EXTERNAL_SENSOR_DBUS_PATH_SOC: Union[str, None] = config["DEFAULT"]["EXTERNAL_SENSOR_DBUS_PATH_SOC"] or None
+EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE: Union[str, None] = config["DEFAULT"]["EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE"] or None
 
 
 # Common configuration checks

--- a/tests/test_external_sensor_override.py
+++ b/tests/test_external_sensor_override.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Tests for the external sensor override (EXTERNAL_SENSOR_DBUS_PATH_*)."""
+
+import utils
+from battery import Battery
+
+
+class _FakeDbusItem:
+    """Minimal stand-in for a VeDbusItemImport."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def get_value(self):
+        return self._value
+
+
+# concrete subclass so the abstract Battery can be instantiated without a BMS
+_ConcreteBattery = type("_ConcreteBattery", (Battery,), {name: lambda self, *a, **kw: None for name in Battery.__abstractmethods__})
+
+
+def _make_battery():
+    battery = _ConcreteBattery.__new__(_ConcreteBattery)
+    battery.voltage = 26.0
+    battery.voltage_calc = None
+    battery.dbus_external_objects = None
+    return battery
+
+
+class TestConfigOptions:
+    """The new options must exist in config.default.ini and be read by utils."""
+
+    def test_utils_exposes_voltage_path(self):
+        assert hasattr(utils, "EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE")
+
+    def test_utils_exposes_temperature_path(self):
+        assert hasattr(utils, "EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE")
+
+    def test_defaults_are_disabled(self):
+        assert utils.EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE is None
+        assert utils.EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE is None
+
+
+class TestGetVoltage:
+    def test_no_external_sensor_returns_bms_voltage(self):
+        battery = _make_battery()
+        assert battery.get_voltage() == 26.0
+
+    def test_external_sensor_overrides_bms_voltage(self):
+        battery = _make_battery()
+        battery.dbus_external_objects = {"Voltage": _FakeDbusItem(26.437)}
+        assert battery.get_voltage() == 26.437
+
+    def test_external_sensor_none_value_falls_back_to_bms(self):
+        battery = _make_battery()
+        battery.dbus_external_objects = {"Voltage": _FakeDbusItem(None)}
+        assert battery.get_voltage() == 26.0
+
+    def test_external_objects_without_voltage_key_falls_back_to_bms(self):
+        battery = _make_battery()
+        battery.dbus_external_objects = {"Current": _FakeDbusItem(-0.2)}
+        assert battery.get_voltage() == 26.0
+
+    def test_external_sensor_value_is_rounded(self):
+        battery = _make_battery()
+        battery.dbus_external_objects = {"Voltage": _FakeDbusItem(26.43759)}
+        assert battery.get_voltage() == 26.438
+
+    def test_no_external_sensor_and_no_bms_voltage_returns_none(self):
+        battery = _make_battery()
+        battery.voltage = None
+        assert battery.get_voltage() is None
+
+
+class TestGetTemperature:
+    def _make_battery_with_temperatures(self):
+        battery = _make_battery()
+        battery.temperature_1 = 20.0
+        battery.temperature_2 = 22.0
+        battery.temperature_3 = None
+        battery.temperature_4 = None
+        return battery
+
+    def test_no_external_sensor_returns_bms_temperature_average(self):
+        battery = self._make_battery_with_temperatures()
+        assert battery.get_temperature() == 21.0
+
+    def test_external_sensor_overrides_bms_temperature(self):
+        battery = self._make_battery_with_temperatures()
+        battery.dbus_external_objects = {"Temperature": _FakeDbusItem(18.73)}
+        assert battery.get_temperature() == 18.7
+
+    def test_external_sensor_none_value_falls_back_to_bms(self):
+        battery = self._make_battery_with_temperatures()
+        battery.dbus_external_objects = {"Temperature": _FakeDbusItem(None)}
+        assert battery.get_temperature() == 21.0
+
+    def test_external_objects_without_temperature_key_falls_back_to_bms(self):
+        battery = self._make_battery_with_temperatures()
+        battery.dbus_external_objects = {"Voltage": _FakeDbusItem(26.4)}
+        assert battery.get_temperature() == 21.0
+
+
+class TestGetPower:
+    def test_power_uses_calculated_voltage(self):
+        battery = _make_battery()
+        battery.voltage_calc = 26.437
+        battery.current_calc = -0.2
+        battery.power_calc = None
+        battery.power_calc_last_time = None
+        assert battery.get_power() == 26.437 * -0.2
+
+    def test_power_none_when_voltage_calc_missing(self):
+        battery = _make_battery()
+        battery.voltage_calc = None
+        battery.current_calc = -0.2
+        battery.power_calc = None
+        battery.power_calc_last_time = None
+        assert battery.get_power() is None


### PR DESCRIPTION
## What this does

Extends the existing external sensor mechanism to **voltage** and **temperature**:

* `EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE`
* `EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE`

Both sit next to the existing `EXTERNAL_SENSOR_DBUS_PATH_CURRENT` / `_SOC` under the same `EXTERNAL_SENSOR_DBUS_DEVICE`, use the same `VeDbusItemImport` plumbing, and are opt-in (empty by default, so nothing changes for existing installations).

## Why

A Victron SmartShunt measures pack voltage and current at the battery terminals with millivolt / sub-amp precision. Many BMS round the current to whole amps and measure the voltage internally, behind the MOSFETs and the sense wiring, so the BMS voltage sags under load relative to the terminals.

Overriding only the current (which is possible today) leaves `/Dc/0/Voltage` on the BMS value, and power is then computed from a shunt current and a BMS voltage — two different instruments. With the voltage path configured, voltage, current and the derived power all come from the shunt, so they are mutually consistent.

Temperature is included for the common case where the shunt has a temperature sense wire at the battery, which is often better placed than the BMS's internal sensor. The external temperature replaces only the *published* battery temperature — the temperature based charge/discharge limits still use the BMS cell temperature sensors, since those are the ones that protect the cells.

## How it composes with the existing options

Each path is independent. You can configure any subset; anything left empty keeps using the BMS value. If the external sensor is unavailable at startup or its D-Bus service disappears later, the driver falls back to the BMS values exactly as it does today for current/SoC — the existing connect/disconnect watcher in `dbushelper.py` was extended to also cover the two new paths.

## Config example

```ini
; --------- External Sensor for Voltage, Current, SoC and/or Temperature ---------
EXTERNAL_SENSOR_DBUS_DEVICE = com.victronenergy.battery.ttyS2
EXTERNAL_SENSOR_DBUS_PATH_VOLTAGE = /Dc/0/Voltage
EXTERNAL_SENSOR_DBUS_PATH_CURRENT = /Dc/0/Current
EXTERNAL_SENSOR_DBUS_PATH_SOC = /Soc
EXTERNAL_SENSOR_DBUS_PATH_TEMPERATURE = /Dc/0/Temperature
```

## Implementation notes

`battery.py` gains a `voltage_calc` field and a `get_voltage()` accessor, mirroring the existing `current_calc` / `get_current()` and `soc_calc` / `get_soc()` pattern: `set_calculated_data()` fills `voltage_calc`, `get_power()` uses it, and `dbushelper.py` publishes `/Dc/0/Voltage` from it. Upstream today has no voltage accessor at all and publishes `battery.voltage` directly, so this plumbing is new.

Note: that same minimal voltage-accessor plumbing (`get_voltage()` and the `/Dc/0/Voltage` publish line) is also needed by my separate fallback-sensor PR, so the two PRs overlap on those few lines. Both are meant to be independently mergeable; whichever merges second I will rebase.

## Testing

New `tests/test_external_sensor_override.py` (15 tests) covers the voltage override, the fallback to the BMS value when the sensor is absent / returns `None` / has no such key, rounding, the temperature branch, and the power calculation using `voltage_calc`.

Verification on this branch:

* `python3 -m py_compile` on all changed files — clean
* `python3 -m flake8 --max-line-length=160` — clean
* `black --check` — clean
* Full `tests/` suite: `18 failed, 90 passed, 28 errors`, versus `18 failed, 75 passed, 28 errors` on `master` — the +15 are the new tests, and the failing/erroring node ID set is byte-identical to the `master` baseline (pre-existing environment failures in `tests/test_utils.py` and `tests/bms/test_lltjbd_up16s.py`, unrelated to this change).

Running in production on a Cerbo GX MK2 with two BLE batteries, each paired with its own SmartShunt supplying voltage, current and temperature.

## Supersedes

This replaces the external-sensor half of #496. That PR bundled this feature together with a separate fallback-device feature across a long history of superseded design; it is being retired in favour of this focused PR (and a separate one for the fallback feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
