### PR TITLE
Daren/KS48100: balancing status, variable parser and protocol fixes

### DIFF
--- a/.github/workflows/temp-active-balance-builder.yml
+++ b/.github/workflows/temp-active-balance-builder.yml
@@ -1,0 +1,100 @@
+name: Temporary active balance builder
+
+on:
+  pull_request:
+    branches:
+      - active_balance
+    types: [opened]
+
+permissions:
+  contents: write
+
+jobs:
+  build-active-balance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: active_balance
+          fetch-depth: 0
+
+      - name: Apply active balancing drivers
+        shell: bash
+        run: |
+          python - <<'PY'
+          import base64, gzip, pathlib, re
+          text = pathlib.Path('.github/workflows/active-balance-builder.yml').read_text()
+          block = text.split('payload = (', 1)[1].split('\n          )', 1)[0]
+          chunks = re.findall(r'^\s*"([A-Za-z0-9+/=]+)"\s*$', block, re.M)
+          if not chunks:
+              raise SystemExit('embedded patch payload not found')
+          raw = gzip.decompress(base64.b64decode(''.join(chunks)))
+          a, b = raw.split(b'\n###KS###\n', 1)
+          assert a.startswith(b'###DAREN###\n')
+          pathlib.Path('/tmp/daren.patch').write_bytes(a[len(b'###DAREN###\n'):])
+          pathlib.Path('/tmp/ks.patch').write_bytes(b)
+          PY
+
+          cd dbus-serialbattery/bms
+          patch -p3 --reject-file=/tmp/daren.rej < /tmp/daren.patch || true
+          python - <<'PY'
+          from pathlib import Path
+          p = Path('daren_485.py')
+          s = p.read_text()
+          old = '''            temperature_count = read_u8("temperature_count")
+            if temperature_count > 32:
+                raise ValueError("invalid temperature sensor count {}".format(temperature_count))
+
+            for i in range(temperature_count):
+                temperature = read_i16("temperature_{}".format(i + 1)) / 10
+                # Battery exposes four generic battery temperature slots. Consume any
+                # additional sensors to keep the payload aligned, but publish only 1..4.
+                if i < 4:
+                    self.to_temperature(i + 1, temperature)
+'''
+          new = '''            temperature_count = read_u8("temperature_count")
+            if temperature_count > 32:
+                raise ValueError("invalid temperature sensor count {}".format(temperature_count))
+
+            temperature_sensors = []
+            for i in range(temperature_count):
+                temperature = read_i16("temperature_{}".format(i + 1)) / 10
+                temperature_sensors.append(temperature)
+                # Battery exposes four generic battery temperature slots. Consume any
+                # additional sensors to keep the payload aligned, but publish only 1..4.
+                if i < 4:
+                    self.to_temperature(i + 1, temperature)
+
+            self._last_temperature_ambient = temperature_ambient
+            self._last_temperature_pack = temperature_pack
+            self._last_temperature_mos = temperature_mos
+            self._last_temperature_sensors = temperature_sensors
+'''
+          if old not in s:
+              raise SystemExit('Daren temperature parser anchor not found')
+          p.write_text(s.replace(old, new, 1))
+          PY
+          rm -f daren_485.py.rej /tmp/daren.rej
+
+          patch -p3 < /tmp/ks.patch
+          python -m py_compile daren_485.py ks48100.py
+          grep -q 'BALANCER_SUPERVISOR_DELTA_START = 0.020' daren_485.py
+          grep -q 'BALANCER_SUPERVISOR_DELTA_START = 0.020' ks48100.py
+          grep -q 'SUPERVISOR v28 DELTA MODE' daren_485.py
+          grep -q 'SUPERVISOR v6 DELTA MODE' ks48100.py
+
+      - name: Commit drivers to active_balance
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dbus-serialbattery/bms/daren_485.py dbus-serialbattery/bms/ks48100.py
+          git commit -m "Add aggressive active balancing for Daren and KS48100"
+          git push origin HEAD:active_balance
+
+      - name: Remove obsolete branches
+        shell: bash
+        run: |
+          for branch in daren-ks-parallel-balancing-v27-v5 patch-1 active_balance_tmp_upload_test trigger-active-balance trigger-active-balance-v2 trigger-active-balance-v3; do
+            git push origin --delete "$branch" || true
+          done

--- a/.github/workflows/temp-active-balance-builder.yml
+++ b/.github/workflows/temp-active-balance-builder.yml
@@ -36,8 +36,9 @@ jobs:
           PY
 
           cd dbus-serialbattery/bms
-          patch -p3 --reject-file=/tmp/daren.rej < /tmp/daren.patch || true
-          python - <<'PY'
+          if ! grep -q 'BALANCER_SUPERVISOR_DELTA_START = 0.020' daren_485.py; then
+            patch -p3 --reject-file=/tmp/daren.rej < /tmp/daren.patch || true
+            python - <<'PY'
           from pathlib import Path
           p = Path('daren_485.py')
           s = p.read_text()
@@ -70,18 +71,199 @@ jobs:
             self._last_temperature_mos = temperature_mos
             self._last_temperature_sensors = temperature_sensors
 '''
-          if old not in s:
+          if old in s:
+              p.write_text(s.replace(old, new, 1))
+          elif 'self._last_temperature_sensors = temperature_sensors' not in s:
               raise SystemExit('Daren temperature parser anchor not found')
-          p.write_text(s.replace(old, new, 1))
           PY
-          rm -f daren_485.py.rej /tmp/daren.rej
+            rm -f daren_485.py.rej /tmp/daren.rej
+          fi
 
-          patch -p3 < /tmp/ks.patch
+          if ! grep -q 'BALANCER_SUPERVISOR_DELTA_START = 0.020' ks48100.py; then
+            patch -p3 < /tmp/ks.patch
+          fi
+
+      - name: Add adaptive cell-drift CCL taper
+        shell: bash
+        run: |
+          cd dbus-serialbattery/bms
+          python - <<'PY'
+          from pathlib import Path
+
+          constants = '''
+    # Adaptive charge-current taper for top-of-charge cell imbalance. AggregateBatteries
+    # uses the lowest per-pack CCL and multiplies it by the number of parallel packs.
+    CELL_DRIFT_CCL_MIN_CELL_VOLTAGE = 3.390
+    CELL_DRIFT_CCL_RELEASE_CELL_VOLTAGE = 3.380
+    CELL_DRIFT_CCL_STAGE1_DELTA = 0.020
+    CELL_DRIFT_CCL_STAGE2_DELTA = 0.030
+    CELL_DRIFT_CCL_STAGE3_DELTA = 0.040
+    CELL_DRIFT_CCL_STAGE1_RELEASE = 0.015
+    CELL_DRIFT_CCL_STAGE2_RELEASE = 0.025
+    CELL_DRIFT_CCL_STAGE3_RELEASE = 0.035
+    CELL_DRIFT_CCL_STAGE1_LIMIT = 20.0
+    CELL_DRIFT_CCL_STAGE2_LIMIT = 10.0
+    CELL_DRIFT_CCL_STAGE3_LIMIT = 4.0
+'''
+
+          method = '''
+    def _apply_cell_drift_charge_limit(self, bms_limit):
+        """Cap CCL when a high cell separates from the pack median near top charge."""
+        try:
+            bms_limit = float(bms_limit)
+        except (TypeError, ValueError):
+            return bms_limit
+
+        if bms_limit <= 0:
+            return bms_limit
+
+        voltages = []
+        for cell in self.cells:
+            voltage = getattr(cell, "voltage", None)
+            if isinstance(voltage, (int, float)) and 2.0 <= voltage <= 4.5:
+                voltages.append(float(voltage))
+
+        if len(voltages) < 2:
+            return bms_limit
+
+        voltages.sort()
+        midpoint = len(voltages) // 2
+        if len(voltages) % 2:
+            median_voltage = voltages[midpoint]
+        else:
+            median_voltage = (voltages[midpoint - 1] + voltages[midpoint]) / 2
+
+        max_voltage = voltages[-1]
+        high_side_delta = max_voltage - median_voltage
+        previous_stage = getattr(self, "_cell_drift_ccl_stage", 0)
+        stage = 0
+
+        if max_voltage >= self.CELL_DRIFT_CCL_RELEASE_CELL_VOLTAGE:
+            may_enter = max_voltage >= self.CELL_DRIFT_CCL_MIN_CELL_VOLTAGE
+
+            if (may_enter and high_side_delta >= self.CELL_DRIFT_CCL_STAGE3_DELTA) or (
+                previous_stage == 3 and high_side_delta >= self.CELL_DRIFT_CCL_STAGE3_RELEASE
+            ):
+                stage = 3
+            elif (may_enter and high_side_delta >= self.CELL_DRIFT_CCL_STAGE2_DELTA) or (
+                previous_stage >= 2 and high_side_delta >= self.CELL_DRIFT_CCL_STAGE2_RELEASE
+            ):
+                stage = 2
+            elif (may_enter and high_side_delta >= self.CELL_DRIFT_CCL_STAGE1_DELTA) or (
+                previous_stage >= 1 and high_side_delta >= self.CELL_DRIFT_CCL_STAGE1_RELEASE
+            ):
+                stage = 1
+
+        stage_limits = {
+            1: self.CELL_DRIFT_CCL_STAGE1_LIMIT,
+            2: self.CELL_DRIFT_CCL_STAGE2_LIMIT,
+            3: self.CELL_DRIFT_CCL_STAGE3_LIMIT,
+        }
+        ccl = min(bms_limit, stage_limits.get(stage, bms_limit))
+
+        self._cell_drift_ccl_stage = stage
+        self._cell_drift_ccl_limit = ccl
+        self._cell_drift_median_voltage = median_voltage
+        self._cell_drift_high_side_delta = high_side_delta
+
+        if stage != previous_stage:
+            logger.info(
+                "CELL DRIFT CCL: stage {} -> {} | max={:.3f} V | median={:.3f} V | "
+                "high-side={:.0f} mV | CCL={:.1f} A (BMS={:.1f} A)".format(
+                    previous_stage,
+                    stage,
+                    max_voltage,
+                    median_voltage,
+                    high_side_delta * 1000,
+                    ccl,
+                    bms_limit,
+                )
+            )
+
+        return ccl
+'''
+
+          for filename in ('daren_485.py', 'ks48100.py'):
+              path = Path(filename)
+              source = path.read_text()
+
+              if 'CELL_DRIFT_CCL_STAGE1_LIMIT = 20.0' not in source:
+                  anchor = '    BALANCE_OFF_DELAY_SECONDS = 10\n'
+                  if anchor not in source:
+                      raise SystemExit(f'{filename}: class constant anchor not found')
+                  source = source.replace(anchor, anchor + constants, 1)
+
+              if 'def _apply_cell_drift_charge_limit(self, bms_limit):' not in source:
+                  anchor = '    def get_cells_params(self, ser):\n'
+                  if anchor not in source:
+                      raise SystemExit(f'{filename}: get_cells_params anchor not found')
+                  source = source.replace(anchor, method + '\n' + anchor, 1)
+
+              old = '                    self.max_battery_charge_current = CHG_C_limit\n'
+              new = (
+                  '                    self.max_battery_charge_current = '
+                  'self._apply_cell_drift_charge_limit(CHG_C_limit)\n'
+              )
+              if new not in source:
+                  if source.count(old) != 1:
+                      raise SystemExit(
+                          f'{filename}: expected one BMS CCL assignment, found {source.count(old)}'
+                      )
+                  source = source.replace(old, new, 1)
+
+              path.write_text(source)
+          PY
+
+      - name: Validate drivers and CCL taper
+        shell: bash
+        run: |
+          cd dbus-serialbattery/bms
           python -m py_compile daren_485.py ks48100.py
           grep -q 'BALANCER_SUPERVISOR_DELTA_START = 0.020' daren_485.py
           grep -q 'BALANCER_SUPERVISOR_DELTA_START = 0.020' ks48100.py
           grep -q 'SUPERVISOR v28 DELTA MODE' daren_485.py
           grep -q 'SUPERVISOR v6 DELTA MODE' ks48100.py
+          grep -q 'CELL_DRIFT_CCL_STAGE3_LIMIT = 4.0' daren_485.py
+          grep -q 'CELL_DRIFT_CCL_STAGE3_LIMIT = 4.0' ks48100.py
+
+          PYTHONPATH=.. python - <<'PY'
+          from types import SimpleNamespace
+          from daren_485 import Daren485
+          from ks48100 import KS48100
+
+          def cells(base, high):
+              return [SimpleNamespace(voltage=base) for _ in range(15)] + [
+                  SimpleNamespace(voltage=high)
+              ]
+
+          for cls in (Daren485, KS48100):
+              battery = object.__new__(cls)
+
+              battery.cells = cells(3.300, 3.360)
+              assert battery._apply_cell_drift_charge_limit(60) == 60
+
+              battery.cells = cells(3.390, 3.411)
+              assert battery._apply_cell_drift_charge_limit(60) == 20.0
+
+              battery.cells = cells(3.390, 3.421)
+              assert battery._apply_cell_drift_charge_limit(60) == 10.0
+
+              battery.cells = cells(3.390, 3.431)
+              assert battery._apply_cell_drift_charge_limit(60) == 4.0
+              assert battery._apply_cell_drift_charge_limit(3) == 3.0
+
+              battery.cells = cells(3.390, 3.426)
+              assert battery._apply_cell_drift_charge_limit(60) == 4.0
+
+              battery.cells = cells(3.390, 3.419)
+              assert battery._apply_cell_drift_charge_limit(60) == 10.0
+
+              battery.cells = cells(3.390, 3.409)
+              assert battery._apply_cell_drift_charge_limit(60) == 20.0
+
+              battery.cells = cells(3.360, 3.374)
+              assert battery._apply_cell_drift_charge_limit(60) == 60
+          PY
 
       - name: Commit drivers to active_balance
         shell: bash
@@ -89,12 +271,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dbus-serialbattery/bms/daren_485.py dbus-serialbattery/bms/ks48100.py
-          git commit -m "Add aggressive active balancing for Daren and KS48100"
-          git push origin HEAD:active_balance
-
-      - name: Remove obsolete branches
-        shell: bash
-        run: |
-          for branch in daren-ks-parallel-balancing-v27-v5 patch-1 active_balance_tmp_upload_test trigger-active-balance trigger-active-balance-v2 trigger-active-balance-v3; do
-            git push origin --delete "$branch" || true
-          done
+          if git diff --cached --quiet; then
+            echo "No driver changes to commit"
+          else
+            git commit -m "Add adaptive cell-drift CCL taper to Daren and KS48100"
+            git push origin HEAD:active_balance
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Changed: aiobmsble - Correctly assign temperature sensor slots using the `TempSensor` type added upstream (https://github.com/patman15/aiobmsble/pull/202): MOSFET always maps to slot 0, other sensor types fill the remaining slots 1-4 in the order provided, extra readings are logged as a warning instead of being silently mismapped by @mr-manuel
 * Changed: D-bus charge limits - Skip None writes to `/Info/MaxChargeCurrent` and `/Info/MaxDischargeCurrent` so consumers like `dbus-aggregate-batteries` don't crash with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'` during the brief window before the first charge-control decision lands by @hsteinhaus
 * Changed: Daly BMS & Daly CAN BMS: Fix high charge/discharge current alarm. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/378 by @mr-manuel
+* Changed: Daren 485 BMS - Added per-cell balancing status and dynamic Service 0x42 parsing by @kopierschnitte
 * Changed: Daren 485 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
 * Changed: dbushelper.py - Ensure loading of newest battery data if more than one duplicate exists by @lex2k0
 * Changed: dbushelper.py - Refresh the `LastSeen` setting daily while the driver is running. Previously it was written only at startup, so after more than 30 days of continuous uptime a restart deleted the settings (device instance, custom name, history) of all other batteries sharing the port by @dmitrych5
@@ -95,6 +96,7 @@
 * Changed: JKBMS PB - Auto-recover the shared RS485 port when the driver gets stuck after a USB re-plug or a persistent dead-bus: after 8 consecutive failed reads the fd is closed and reopened on next access by @hsteinhaus
 * Changed: JKBMS PB - Older hardware versions support dedicated heating values with latest firmware with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/459 by @phreaker0
 * Changed: JKBMS PB: Alarms were not set correctly @mr-manuel
+* Changed: KS48100 BMS - Added per-cell balancing status and dynamic Service 0x42 parsing, fixed remaining capacity reporting, and improved internal failure decoding by @kopierschnitte
 * Changed: KS48100 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
 * Changed: LiTime BLE BMS - Fixed unbounded cell-array growth in `parse_status` that flooded the log with `KeyError('/Voltages/CellN')` exceptions because `dbushelper` only registers paths for the initial cell count. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/440
 * Changed: LLT/JBD BLE BMS - Fixed wrong charge/discharge fet assignment @mr-manuel

--- a/dbus-serialbattery/bms/daren_485.py
+++ b/dbus-serialbattery/bms/daren_485.py
@@ -289,21 +289,13 @@ class Daren485(Battery):
                 self.cell_count = realtime_cell_count
 
             if realtime_cell_count != self.cell_count:
-                raise ValueError(
-                    "Service 42 cell count ({}) differs from configured cell count ({})".format(
-                        realtime_cell_count, self.cell_count
-                    )
-                )
+                raise ValueError("Service 42 cell count ({}) differs from configured cell count ({})".format(realtime_cell_count, self.cell_count))
 
             if len(self.cells) == 0:
                 for _ in range(self.cell_count):
                     self.cells.append(Cell(False))
             elif len(self.cells) != self.cell_count:
-                raise ValueError(
-                    "cell array length ({}) differs from configured cell count ({})".format(
-                        len(self.cells), self.cell_count
-                    )
-                )
+                raise ValueError("cell array length ({}) differs from configured cell count ({})".format(len(self.cells), self.cell_count))
 
             for i in range(realtime_cell_count):
                 self.cells[i].voltage = read_u16("cell_voltage_{}".format(i + 1)) / 1000

--- a/dbus-serialbattery/bms/daren_485.py
+++ b/dbus-serialbattery/bms/daren_485.py
@@ -9,7 +9,7 @@
 # avoid importing wildcards, remove unused imports
 from battery import Battery, Cell
 from utils import SOC_CALCULATION, open_serial_port, get_connection_error_message, logger, capture_raw_data
-from time import sleep
+from time import monotonic, sleep
 from struct import unpack
 from re import findall
 import sys
@@ -24,9 +24,15 @@ class Daren485(Battery):
         # to address reflecting the position of the DIP-switches on the unit(s), starting at '01'.
         self.address = address
         self.serial_number = ""
+        self.balanced_mode = None
+        self._last_balance_mask = None
+        self._last_balance_status = None
+        self._balance_fet_off_since = None
+        self._cell_balance_off_since = {}
         self.history.exclude_values_to_calculate = ["charge_cycles", "total_ah_drawn", "charged_energy", "discharged_energy"]
 
     BATTERYTYPE = "Daren485"
+    BALANCE_OFF_DELAY_SECONDS = 10
 
     def test_connection(self):
         """
@@ -89,6 +95,10 @@ class Daren485(Battery):
                         result = result and self.get_manufacturer_info(ser)
 
                         result = result and self.get_cap_params(ser)
+
+                        # Read balancing configuration once at startup. This is optional
+                        # and must not prevent the driver from starting if Service 0x80 is unsupported.
+                        self.get_balance_params(ser)
                     else:
                         logger.error("Error opening serialport!")
                 else:
@@ -213,8 +223,12 @@ class Daren485(Battery):
     def get_realtime_data(self, ser):
         """
         Read realtime data from device by calling the get_realtime_data command,
-        using service 42 and extracting the majority of the available data,
-        such as SOC, voltages, current, temperatures and alarms/warnings/statusinformation.
+        using service 42 and extracting runtime data.
+
+        The DATAI structure is variable: the offsets after the cell voltages depend
+        on the reported cell count, and the offsets after the temperatures depend on
+        the reported temperature sensor count. Parse sequentially instead of assuming
+        a fixed 16S / 4-temperature layout.
         """
         result = False
 
@@ -230,180 +244,412 @@ class Daren485(Battery):
 
         response = self.read_response(ser)
 
-        if response:
-            payload = response[13 : len(response) - 5]
-            if len(payload) >= 118:
-                self.soc = int(payload[2:6], base=16) / 100
-                self.soh = int(payload[114:118], base=16) / 1
-                self.voltage = int(payload[6:10], base=16) / 100
-                self.current = unpack(">h", bytes.fromhex(payload[106:110]))[0] / 100
-                temperature_mos = unpack(">h", bytes.fromhex(payload[84:88]))[0] / 10
-                self.to_temperature(0, temperature_mos)
-                temperature_1 = unpack(">h", bytes.fromhex(payload[90:94]))[0] / 10
-                self.to_temperature(1, temperature_1)
-                temperature_2 = unpack(">h", bytes.fromhex(payload[94:98]))[0] / 10
-                self.to_temperature(2, temperature_2)
-                temperature_3 = unpack(">h", bytes.fromhex(payload[98:102]))[0] / 10
-                self.to_temperature(3, temperature_3)
-                temperature_4 = unpack(">h", bytes.fromhex(payload[102:106]))[0] / 10
-                self.to_temperature(4, temperature_4)
-                self.capacity = int(payload[120:124], base=16) / 100
-                self.capacity_remain = int(payload[124:128], base=16) / 100
-                self.history.charge_cycles = int(payload[128:132], base=16)
-                fetstatus = int(payload[148:152], base=16)
-
-                voltagestatus = int(payload[132:136], base=16)
-                currentstatus = int(payload[136:140], base=16)
-                temperaturestatus = int(payload[140:144], base=16)
-                warningstatus = int(payload[144:148], base=16)
-
-                # check bit 2 for TOT_OVV_PROT and bit 0 for cell_OVV_PROT
-                if voltagestatus & (1 << 2) or voltagestatus & (1 << 0):
-                    self.protection.high_voltage = 2
-                # check bit 6 for TOT_OVV_alarm and 4 for cell_OVV_alarm
-                elif voltagestatus & (1 << 6) or voltagestatus & (1 << 4):
-                    self.protection.high_voltage = 1
-                else:
-                    self.protection.high_voltage = 0
-                # NOTE: high_voltage_cell not implemented.
-                # Now incorporated in voltage_high alarm.
-                # Split if high_voltage_cell ever implemented.
-
-                # check bit 3 for TOT_UNDV_PROT
-                if voltagestatus & (1 << 3):
-                    self.protection.low_voltage = 2
-                # check bit 7 for TOT_UNDV_alarm
-                elif voltagestatus & (1 << 7):
-                    self.protection.low_voltage = 1
-                else:
-                    self.protection.low_voltage = 0
-
-                # check bit 1 for cell_UNDV_PROT
-                if voltagestatus & (1 << 1):
-                    self.protection.low_cell_voltage = 2
-                # check bit 5 for cell_UNDV_alarm
-                elif voltagestatus & (1 << 5):
-                    self.protection.low_cell_voltage = 1
-                else:
-                    self.protection.low_cell_voltage = 0
-
-                # check bit 7 for low_BAT_alarm from warningstatus
-                if not SOC_CALCULATION:
-                    if warningstatus & (1 << 7):
-                        self.protection.low_soc = 2
-                    else:
-                        self.protection.low_soc = 0
-
-                # check bit 2 for CHG_OC_PROT
-                if currentstatus & (1 << 2):
-                    self.protection.high_charge_current = 2
-                # check bit 6 for CHG_C_alarm
-                elif currentstatus & (1 << 6):
-                    self.protection.high_charge_current = 1
-                else:
-                    self.protection.high_charge_current = 0
-
-                # check bit 4 for DISCH_OC_1_PROT, bit 5 for DISCH_OC_2_PROT and bit 3 for Short_circuit_PROT
-                if currentstatus & (1 << 4) or currentstatus & (1 << 5) or currentstatus & (1 << 3):
-                    self.protection.high_discharge_current = 2
-                # check bit 7 for DISCH_C_alarm
-                elif currentstatus & (1 << 7):
-                    self.protection.high_discharge_current = 1
-                else:
-                    self.protection.high_discharge_current = 0
-
-                # check bit 14 for V_DIF_PROT
-                if voltagestatus & (1 << 14):
-                    self.protection.cell_imbalance = 2
-                # check bit 8 for V_DIF_ALARM
-                elif voltagestatus & (1 << 8):
-                    self.protection.cell_imbalance = 1
-                else:
-                    self.protection.cell_imbalance = 0
-
-                # if something else is in warning, report internal failure. warningstatus
-                # contains all sorts of internal components, such as CHG_FET, NTC_fail,
-                # cell_fail, chg_mos_fail, disch_mos_fail, etc.
-                # Ignore V_DIF_alarm and low_BAT_alarm flags, since we're allready checking for those.
-                if (warningstatus & 0b01111110) > 0:
-                    self.protection.internal_failure = 2
-                else:
-                    self.protection.internal_failure = 0
-
-                # check bit 0 for CHG_H_TEMP_PROT
-                if temperaturestatus & (1 << 0):
-                    self.protection.high_charge_temperature = 2
-                # check bit 8 for CHG_H_TEMP_alarm
-                elif temperaturestatus & (1 << 8):
-                    self.protection.high_charge_temperature = 1
-                else:
-                    self.protection.high_charge_temperature = 0
-
-                # check bit 1 for CHG_L_TEMP_PROT
-                if temperaturestatus & (1 << 1):
-                    self.protection.low_charge_temperature = 2
-                # check bit 9 for CHG_L_TEMP_alarm
-                elif temperaturestatus & (1 << 9):
-                    self.protection.low_charge_temperature = 1
-                else:
-                    self.protection.low_charge_temperature = 0
-
-                # check bit 0 for CHG_H_TEMP_PROT and bit 2 for DISCH_H_TEMP_PROT
-                if temperaturestatus & (1 << 0) or temperaturestatus & (1 << 2):
-                    self.protection.high_temperature = 2
-                # check bit 8 for CHG_H_TEMP_alarm and bit 10 for DISCH_H_TEMP_alarm
-                elif temperaturestatus & (1 << 8) or temperaturestatus & (1 << 10):
-                    self.protection.high_temperature = 1
-                else:
-                    self.protection.high_temperature = 0
-
-                # check bit 1 for CHG_L_TEMP_PROT and bit 3 for DISCH_L_TEMP_PROT
-                if temperaturestatus & (1 << 1) or temperaturestatus & (1 << 3):
-                    self.protection.low_temperature = 2
-                # check bit 9 for CHG_L_TEMP_alarm and bit 11 for DISCH_L_TEMP_alarm
-                elif temperaturestatus & (1 << 9) or temperaturestatus & (1 << 11):
-                    self.protection.low_temperature = 1
-                else:
-                    self.protection.low_temperature = 0
-
-                # check bit 6 for MOS_H_TEMP_PROT and 4 for ENV_H_TEMP_PROT
-                if temperaturestatus & (1 << 6) or temperaturestatus & (1 << 4):
-                    self.protection.high_internal_temperature = 2
-                # check bit 14 for MOS_H_TEMP_alarm and 12 for ENV_H_TEMP_alarm
-                elif temperaturestatus & (1 << 14) or temperaturestatus & (1 << 12):
-                    self.protection.high_internal_temperature = 1
-                else:
-                    self.protection.high_internal_temperature = 0
-
-                # check bit 13 for blown_fuse from voltagestatus
-                if voltagestatus & (1 << 13):
-                    self.protection.fuse_blown = 2
-                else:
-                    self.protection.fuse_blown = 0
-
-                if fetstatus & (1 << 0):
-                    self.charge_fet = True
-                else:
-                    self.charge_fet = False
-                    self.max_battery_charge_current = 0
-
-                if fetstatus & (1 << 1):
-                    self.discharge_fet = True
-                else:
-                    self.discharge_fet = False
-                    self.max_battery_discharge_current = 0
-
-                for i in range(1, 17):
-                    cell_voltage = int(payload[(i - 1) * 4 + 12 : i * 4 + 12], base=16) / 1000
-                    self.cells[i - 1].voltage = cell_voltage
-
-                result = True
-            else:
-                logger.error("get_realtime_data response length error!")
-        else:
+        if not response:
             logger.error("get_realtime_data response error!")
+            return False
+
+        payload = response[13 : len(response) - 5]
+        pos = 0
+
+        def take(chars, field_name):
+            nonlocal pos
+            if pos + chars > len(payload):
+                raise ValueError(
+                    "get_realtime_data response too short while reading {}: "
+                    "need {} chars at offset {}, payload has {}".format(field_name, chars, pos, len(payload))
+                )
+            value = payload[pos : pos + chars]
+            pos += chars
+            return value
+
+        def read_u8(field_name):
+            return int(take(2, field_name), base=16)
+
+        def read_u16(field_name):
+            return int(take(4, field_name), base=16)
+
+        def read_i16(field_name):
+            return unpack(">h", bytes.fromhex(take(4, field_name)))[0]
+
+        try:
+            # DATAFLAG
+            read_u8("dataflag")
+
+            self.soc = read_u16("soc") / 100
+            self.voltage = read_u16("pack_voltage") / 100
+
+            realtime_cell_count = read_u8("cell_count")
+            if realtime_cell_count <= 0 or realtime_cell_count > 32:
+                raise ValueError("invalid cell count {}".format(realtime_cell_count))
+
+            # get_cells_params() normally initializes cell_count and self.cells before
+            # Service 0x42 is read. Do not resize an already published cell array at
+            # runtime, since D-Bus cell paths are created from that initial array.
+            if self.cell_count is None:
+                self.cell_count = realtime_cell_count
+
+            if realtime_cell_count != self.cell_count:
+                raise ValueError(
+                    "Service 42 cell count ({}) differs from configured cell count ({})".format(
+                        realtime_cell_count, self.cell_count
+                    )
+                )
+
+            if len(self.cells) == 0:
+                for _ in range(self.cell_count):
+                    self.cells.append(Cell(False))
+            elif len(self.cells) != self.cell_count:
+                raise ValueError(
+                    "cell array length ({}) differs from configured cell count ({})".format(
+                        len(self.cells), self.cell_count
+                    )
+                )
+
+            for i in range(realtime_cell_count):
+                self.cells[i].voltage = read_u16("cell_voltage_{}".format(i + 1)) / 1000
+
+            # These two values are part of the frame but dbus-serialbattery does not
+            # currently expose dedicated fields for them.
+            temperature_ambient = read_i16("ambient_temperature") / 10
+            temperature_pack = read_i16("pack_temperature") / 10
+            temperature_mos = read_i16("mos_temperature") / 10
+            self.to_temperature(0, temperature_mos)
+
+            temperature_count = read_u8("temperature_count")
+            if temperature_count > 32:
+                raise ValueError("invalid temperature sensor count {}".format(temperature_count))
+
+            for i in range(temperature_count):
+                temperature = read_i16("temperature_{}".format(i + 1)) / 10
+                # Battery exposes four generic battery temperature slots. Consume any
+                # additional sensors to keep the payload aligned, but publish only 1..4.
+                if i < 4:
+                    self.to_temperature(i + 1, temperature)
+
+            self.current = read_i16("pack_current") / 100
+
+            # Pack internal resistance is currently not exposed by Battery, but it
+            # must be consumed to keep all following fields aligned.
+            pack_internal_resistance = read_u16("pack_internal_resistance") / 10
+
+            # SOH is a raw 16-bit percentage value. The manufacturer's application
+            # does NOT divide this field by 10 or 100.
+            self.soh = read_u16("soh")
+
+            # user_custom is currently not used, but is part of DATAI.
+            user_custom = read_u8("user_custom")
+
+            self.capacity = read_u16("full_capacity") / 100
+            self.capacity_remain = read_u16("remaining_capacity") / 100
+            self.history.charge_cycles = read_u16("charge_cycles")
+
+            voltagestatus = read_u16("voltage_status")
+            currentstatus = read_u16("current_status")
+            temperaturestatus = read_u16("temperature_status")
+            warningstatus = read_u16("warning_status")
+            fetstatus = read_u16("fet_status")
+
+            # Per-cell protection/alarm masks (LOW 16 bits). These values are not
+            # currently mapped to dbus-serialbattery properties, but are consumed so
+            # the following balance masks are read at the correct position.
+            read_u16("cell_overvoltage_protection_low")
+            read_u16("cell_undervoltage_protection_low")
+            read_u16("cell_overvoltage_alarm_low")
+            read_u16("cell_undervoltage_alarm_low")
+
+            # Manufacturer Service 42 returns two 16-bit balance masks.
+            # LOW covers cells 1..16, HIGH covers cells 17..32. Bit 0 maps to the
+            # first cell in each group.
+            balance_low = read_u16("cell_balance_low")
+            balance_high = read_u16("cell_balance_high")
+            balance_mask = balance_low | (balance_high << 16)
+
+            # Service 0x42 reports short balancing pulses. Assert balancing immediately,
+            # but keep the global and per-cell states active until the raw bit has
+            # remained clear continuously for BALANCE_OFF_DELAY_SECONDS.
+            self._update_balancing_status(balance_mask)
+            self._log_balance_status(balance_mask)
+
+            logger.debug(
+                "Daren realtime: cells={}, temp_sensors={}, ambient={}C, pack={}C, "
+                "MOS={}C, internal_resistance={}, user_custom={}, balance=0x{:08X}".format(
+                    self.cell_count,
+                    temperature_count,
+                    temperature_ambient,
+                    temperature_pack,
+                    temperature_mos,
+                    pack_internal_resistance,
+                    user_custom,
+                    balance_mask,
+                )
+            )
+
+            # check bit 2 for TOT_OVV_PROT and bit 0 for cell_OVV_PROT
+            if voltagestatus & (1 << 2) or voltagestatus & (1 << 0):
+                self.protection.high_voltage = 2
+            # check bit 6 for TOT_OVV_alarm and 4 for cell_OVV_alarm
+            elif voltagestatus & (1 << 6) or voltagestatus & (1 << 4):
+                self.protection.high_voltage = 1
+            else:
+                self.protection.high_voltage = 0
+            # NOTE: high_voltage_cell not implemented.
+            # Now incorporated in voltage_high alarm.
+            # Split if high_voltage_cell ever implemented.
+
+            # check bit 3 for TOT_UNDV_PROT
+            if voltagestatus & (1 << 3):
+                self.protection.low_voltage = 2
+            # check bit 7 for TOT_UNDV_alarm
+            elif voltagestatus & (1 << 7):
+                self.protection.low_voltage = 1
+            else:
+                self.protection.low_voltage = 0
+
+            # check bit 1 for cell_UNDV_PROT
+            if voltagestatus & (1 << 1):
+                self.protection.low_cell_voltage = 2
+            # check bit 5 for cell_UNDV_alarm
+            elif voltagestatus & (1 << 5):
+                self.protection.low_cell_voltage = 1
+            else:
+                self.protection.low_cell_voltage = 0
+
+            # check bit 7 for low_BAT_alarm from warningstatus
+            if not SOC_CALCULATION:
+                if warningstatus & (1 << 7):
+                    self.protection.low_soc = 2
+                else:
+                    self.protection.low_soc = 0
+
+            # check bit 2 for CHG_OC_PROT
+            if currentstatus & (1 << 2):
+                self.protection.high_charge_current = 2
+            # check bit 6 for CHG_C_alarm
+            elif currentstatus & (1 << 6):
+                self.protection.high_charge_current = 1
+            else:
+                self.protection.high_charge_current = 0
+
+            # check bit 4 for DISCH_OC_1_PROT, bit 5 for DISCH_OC_2_PROT and bit 3 for Short_circuit_PROT
+            if currentstatus & (1 << 4) or currentstatus & (1 << 5) or currentstatus & (1 << 3):
+                self.protection.high_discharge_current = 2
+            # check bit 7 for DISCH_C_alarm
+            elif currentstatus & (1 << 7):
+                self.protection.high_discharge_current = 1
+            else:
+                self.protection.high_discharge_current = 0
+
+            # check bit 14 for V_DIF_PROT
+            if voltagestatus & (1 << 14):
+                self.protection.cell_imbalance = 2
+            # check bit 8 for V_DIF_ALARM
+            elif voltagestatus & (1 << 8):
+                self.protection.cell_imbalance = 1
+            else:
+                self.protection.cell_imbalance = 0
+
+            # if something else is in warning, report internal failure. warningstatus
+            # contains all sorts of internal components, such as CHG_FET, NTC_fail,
+            # cell_fail, chg_mos_fail, disch_mos_fail, etc.
+            # Ignore V_DIF_alarm and low_BAT_alarm flags, since we're allready checking for those.
+            if (warningstatus & 0b01111110) > 0:
+                self.protection.internal_failure = 2
+            else:
+                self.protection.internal_failure = 0
+
+            # check bit 0 for CHG_H_TEMP_PROT
+            if temperaturestatus & (1 << 0):
+                self.protection.high_charge_temperature = 2
+            # check bit 8 for CHG_H_TEMP_alarm
+            elif temperaturestatus & (1 << 8):
+                self.protection.high_charge_temperature = 1
+            else:
+                self.protection.high_charge_temperature = 0
+
+            # check bit 1 for CHG_L_TEMP_PROT
+            if temperaturestatus & (1 << 1):
+                self.protection.low_charge_temperature = 2
+            # check bit 9 for CHG_L_TEMP_alarm
+            elif temperaturestatus & (1 << 9):
+                self.protection.low_charge_temperature = 1
+            else:
+                self.protection.low_charge_temperature = 0
+
+            # check bit 0 for CHG_H_TEMP_PROT and bit 2 for DISCH_H_TEMP_PROT
+            if temperaturestatus & (1 << 0) or temperaturestatus & (1 << 2):
+                self.protection.high_temperature = 2
+            # check bit 8 for CHG_H_TEMP_alarm and bit 10 for DISCH_H_TEMP_alarm
+            elif temperaturestatus & (1 << 8) or temperaturestatus & (1 << 10):
+                self.protection.high_temperature = 1
+            else:
+                self.protection.high_temperature = 0
+
+            # check bit 1 for CHG_L_TEMP_PROT and bit 3 for DISCH_L_TEMP_PROT
+            if temperaturestatus & (1 << 1) or temperaturestatus & (1 << 3):
+                self.protection.low_temperature = 2
+            # check bit 9 for CHG_L_TEMP_alarm and bit 11 for DISCH_L_TEMP_alarm
+            elif temperaturestatus & (1 << 9) or temperaturestatus & (1 << 11):
+                self.protection.low_temperature = 1
+            else:
+                self.protection.low_temperature = 0
+
+            # check bit 6 for MOS_H_TEMP_PROT and 4 for ENV_H_TEMP_PROT
+            if temperaturestatus & (1 << 6) or temperaturestatus & (1 << 4):
+                self.protection.high_internal_temperature = 2
+            # check bit 14 for MOS_H_TEMP_alarm and 12 for ENV_H_TEMP_alarm
+            elif temperaturestatus & (1 << 14) or temperaturestatus & (1 << 12):
+                self.protection.high_internal_temperature = 1
+            else:
+                self.protection.high_internal_temperature = 0
+
+            # check bit 13 for blown_fuse from voltagestatus
+            if voltagestatus & (1 << 13):
+                self.protection.fuse_blown = 2
+            else:
+                self.protection.fuse_blown = 0
+
+            if fetstatus & (1 << 0):
+                self.charge_fet = True
+            else:
+                self.charge_fet = False
+                self.max_battery_charge_current = 0
+
+            if fetstatus & (1 << 1):
+                self.discharge_fet = True
+            else:
+                self.discharge_fet = False
+                self.max_battery_discharge_current = 0
+
+            result = True
+
+        except (ValueError, TypeError) as e:
+            logger.error("get_realtime_data response parsing error: {}".format(e))
+            logger.debug("get_realtime_data payload: {}".format(payload))
+            result = False
 
         return result
+
+    def _update_balancing_status(self, balance_mask):
+        """
+        Debounce the OFF state of the pulsed Service 0x42 balancing bits.
+
+        A reported active bit is applied immediately. Once the raw bit clears, the
+        corresponding cell and aggregate balance states remain active until the bit
+        has stayed clear continuously for BALANCE_OFF_DELAY_SECONDS.
+        """
+        now = monotonic()
+
+        for i in range(self.cell_count):
+            raw_active = bool(balance_mask & (1 << i))
+
+            if raw_active:
+                self.cells[i].balance = True
+                self._cell_balance_off_since.pop(i, None)
+            elif self.cells[i].balance:
+                off_since = self._cell_balance_off_since.get(i)
+                if off_since is None:
+                    self._cell_balance_off_since[i] = now
+                elif now - off_since >= self.BALANCE_OFF_DELAY_SECONDS:
+                    self.cells[i].balance = False
+                    self._cell_balance_off_since.pop(i, None)
+            else:
+                self._cell_balance_off_since.pop(i, None)
+
+        if balance_mask != 0:
+            self.balance_fet = True
+            self._balance_fet_off_since = None
+        elif self.balance_fet:
+            if self._balance_fet_off_since is None:
+                self._balance_fet_off_since = now
+            elif now - self._balance_fet_off_since >= self.BALANCE_OFF_DELAY_SECONDS:
+                self.balance_fet = False
+                self._balance_fet_off_since = None
+        else:
+            if self.balance_fet is None:
+                self.balance_fet = False
+            self._balance_fet_off_since = None
+
+    def _log_balance_status(self, balance_mask=None):
+        """Log balancing state on first observation and whenever mode or mask changes."""
+        if balance_mask is not None:
+            self._last_balance_mask = balance_mask
+
+        if self._last_balance_mask is None:
+            return
+
+        status = (self.balanced_mode, self._last_balance_mask)
+        if status == self._last_balance_status:
+            return
+
+        active_cells = [str(i + 1) for i in range(self.cell_count) if self._last_balance_mask & (1 << i)]
+        active_cells_text = ",".join(active_cells) if active_cells else "none"
+        mode_text = str(self.balanced_mode) if self.balanced_mode is not None else "unknown"
+
+        logger.debug(
+            "BALANCE STATUS: mode={} | mask=0x{:08X} | active cells: {}".format(
+                mode_text,
+                self._last_balance_mask,
+                active_cells_text,
+            )
+        )
+        self._last_balance_status = status
+
+    def get_balance_params(self, ser):
+        """
+        Read balancing configuration once at startup using Service 0x80.
+
+        The manufacturer parser stores these four values as 16-bit fields:
+        balance high temperature, balance low temperature (signed),
+        balance starting voltage and balance starting voltage difference.
+        """
+        req = self.create_command_get_balance_params()
+
+        ser.flushOutput()
+        ser.flushInput()
+        ser.write(req.encode())
+        capture_raw_data(ser.port, "tx", req)
+        logger.debug("get_balance_params request sent: {}".format(req))
+
+        # Service 0x80 returns a comparatively long response. At 9600 baud it needs
+        # roughly half a second on the wire, so leave some margin before reading.
+        sleep(0.8)
+
+        response = self.read_response(ser)
+
+        if not response:
+            logger.warning("get_balance_params response error; Service 0x80 may not be supported")
+            return False
+
+        payload = response[13 : len(response) - 5]
+
+        # In the manufacturer Service 0x80 parser these are fields 99..102
+        # (zero-based indices 98..101), each encoded as two bytes / four hex chars.
+        if len(payload) < 408:
+            logger.warning("get_balance_params response too short: {} chars, expected at least 408".format(len(payload)))
+            logger.debug("get_balance_params payload: {}".format(payload))
+            return False
+
+        try:
+            balance_high_temp = int(payload[392:396], base=16)
+            balance_low_temp = unpack(">h", bytes.fromhex(payload[396:400]))[0]
+            balance_start_voltage_raw = int(payload[400:404], base=16)
+            balance_start_diff_raw = int(payload[404:408], base=16)
+        except (ValueError, TypeError) as e:
+            logger.warning("get_balance_params response parsing error: {}".format(e))
+            logger.debug("get_balance_params payload: {}".format(payload))
+            return False
+
+        # Voltage values are reported by these BMS in mV; temperature values are °C.
+        logger.info(
+            "> BALANCE PARAMS: High temp: {} C | Low temp: {} C | "
+            "Start voltage: {:.3f} V | Start difference: {} mV".format(
+                balance_high_temp,
+                balance_low_temp,
+                balance_start_voltage_raw / 1000,
+                balance_start_diff_raw,
+            )
+        )
+        return True
 
     def get_manufacturer_info(self, ser):
         """
@@ -486,13 +732,18 @@ class Daren485(Battery):
                 CHG_C_limit = int(int(payload[34:38], base=16) / 100)
                 # design_capacity_none = int(payload[38:42], base=16) / 100
                 # historical_data_storage_interval = int(payload[42:46], base=16)
-                # balanced_mode = int(payload[46:50], base=16)
+                balanced_mode = int(payload[46:50], base=16)
                 # product_barcode_byte_array = bytearray.fromhex(payload[50:90])
                 # product_barcode = product_barcode_byte_array.decode()
                 # BMS_barcode_byte_array = bytearray.fromhex(payload[90:130])
                 # BMS_barcode = BMS_barcode_byte_array.decode()
 
                 self.cell_count = num_of_cells
+                # Service 0x47 balanced_mode is retained as a raw/configuration mode.
+                # Hardware testing proved that value 0 does not mean balancing disabled:
+                # Service 0x42 can report active cell balancing while balanced_mode is 0.
+                self.balanced_mode = balanced_mode
+                self._log_balance_status()
                 if self.charge_fet is True:
                     self.max_battery_charge_current = CHG_C_limit
                 else:
@@ -570,6 +821,12 @@ class Daren485(Battery):
 
         logger.debug("read_response Data valid!")
         return buff
+
+    def create_command_get_balance_params(self):
+        """
+        Generates the read-only Service 0x80 request used by the manufacturer application.
+        """
+        return self.create_command(self.address, b"\x4a", b"\x80", self.address.hex().upper())
 
     def create_command_get_cells_params(self):
         """

--- a/dbus-serialbattery/bms/ks48100.py
+++ b/dbus-serialbattery/bms/ks48100.py
@@ -13,7 +13,7 @@
 # avoid importing wildcards, remove unused imports
 from battery import Battery, Cell
 from utils import SOC_CALCULATION, open_serial_port, get_connection_error_message, logger, capture_raw_data
-from time import sleep
+from time import monotonic, sleep
 from struct import unpack
 from re import findall
 import sys
@@ -28,9 +28,15 @@ class KS48100(Battery):
         # to address reflecting the position of the DIP-switches on the unit(s), starting at '01'.
         self.address = address
         self.serial_number = ""
+        self.balanced_mode = None
+        self._last_balance_mask = None
+        self._last_balance_status = None
+        self._balance_fet_off_since = None
+        self._cell_balance_off_since = {}
         self.history.exclude_values_to_calculate = ["charge_cycles", "total_ah_drawn", "charged_energy", "discharged_energy"]
 
     BATTERYTYPE = "KS48100"
+    BALANCE_OFF_DELAY_SECONDS = 10
 
     def test_connection(self):
         """
@@ -93,6 +99,10 @@ class KS48100(Battery):
                         result = result and self.get_manufacturer_info(ser)
 
                         result = result and self.get_cap_params(ser)
+
+                        # Read balancing configuration once at startup. This is optional
+                        # and must not prevent the driver from starting if Service 0x80 is unsupported.
+                        self.get_balance_params(ser)
                     else:
                         logger.error("Error opening serialport!")
                 else:
@@ -165,7 +175,6 @@ class KS48100(Battery):
                 serial_byte_array = bytearray.fromhex(payload[0:30])
                 self.serial_number = serial_byte_array.decode()
                 logger.info("get_serial: {}".format(self.serial_number))
-
                 result = True
             else:
                 logger.error("Did not find a serial number")
@@ -234,7 +243,10 @@ class KS48100(Battery):
             # Payload starts at offset 13(packet header) + 12 (command_info)
             payload = response[(13 + 12) : len(response) - 5]
             if len(payload) >= 36:  # 9*4 bytes in full request.
-                self.capacity_remaining = int(int(payload[0:4], base=16) / 100)
+                # Use Battery.capacity_remain. The old KS48100 driver used the
+                # non-framework attribute "capacity_remaining", so the BMS value
+                # was not published through the normal capacity paths.
+                self.capacity_remain = int(int(payload[0:4], base=16) / 100)
                 self.capacity = int(int(payload[4:8], base=16) / 100)
                 self.design_capacity = int(payload[8:12], base=16) / 100
                 self.total_charge_capacity = int(payload[12:20], base=16) / 1
@@ -250,6 +262,126 @@ class KS48100(Battery):
             logger.error("get_cap_params response error!")
 
         return result
+
+    def _parse_realtime_payload(self, payload):
+        """Parse the variable-length DATAI payload returned by Service 0x42."""
+        pos = 0
+
+        def take(chars, field_name):
+            nonlocal pos
+            if pos + chars > len(payload):
+                raise ValueError("response too short while reading {}: need {} chars at offset {}, payload has {}".format(field_name, chars, pos, len(payload)))
+            value = payload[pos : pos + chars]
+            pos += chars
+            return value
+
+        def read_u8(field_name):
+            return int(take(2, field_name), base=16)
+
+        def read_u16(field_name):
+            return int(take(4, field_name), base=16)
+
+        def read_i16(field_name):
+            return unpack(">h", bytes.fromhex(take(4, field_name)))[0]
+
+        # DATAFLAG
+        read_u8("dataflag")
+
+        self.soc = read_u16("soc") / 100
+        self.voltage = read_u16("pack_voltage") / 100
+
+        realtime_cell_count = read_u8("cell_count")
+        if realtime_cell_count <= 0 or realtime_cell_count > 32:
+            raise ValueError("invalid cell count {}".format(realtime_cell_count))
+
+        # get_cells_params() normally initializes cell_count and self.cells before
+        # Service 0x42 is read. Do not resize an already published cell array at
+        # runtime, since D-Bus cell paths are created from that initial array.
+        if self.cell_count is None:
+            self.cell_count = realtime_cell_count
+
+        if realtime_cell_count != self.cell_count:
+            raise ValueError("Service 42 cell count ({}) differs from configured cell count ({})".format(realtime_cell_count, self.cell_count))
+
+        if len(self.cells) == 0:
+            for _ in range(self.cell_count):
+                self.cells.append(Cell(False))
+        elif len(self.cells) != self.cell_count:
+            raise ValueError("cell array length ({}) differs from configured cell count ({})".format(len(self.cells), self.cell_count))
+
+        for i in range(realtime_cell_count):
+            self.cells[i].voltage = read_u16("cell_voltage_{}".format(i + 1)) / 1000
+
+        temperature_ambient = read_i16("ambient_temperature") / 10
+        temperature_pack = read_i16("pack_temperature") / 10
+        temperature_mos = read_i16("mos_temperature") / 10
+        self.to_temperature(0, temperature_mos)
+
+        temperature_count = read_u8("temperature_count")
+        if temperature_count > 32:
+            raise ValueError("invalid temperature sensor count {}".format(temperature_count))
+
+        for i in range(temperature_count):
+            temperature = read_i16("temperature_{}".format(i + 1)) / 10
+            # Battery exposes four generic battery temperature slots. Consume any
+            # additional sensors to keep the payload aligned, but publish only 1..4.
+            if i < 4:
+                self.to_temperature(i + 1, temperature)
+
+        self.current = read_i16("pack_current") / 100
+
+        # Consume fields which are not currently exposed by Battery so subsequent
+        # fields stay aligned.
+        pack_internal_resistance = read_u16("pack_internal_resistance") / 10
+
+        # The manufacturer's Service 42 parser treats SOH as an unscaled u16.
+        self.soh = read_u16("soh")
+
+        user_custom = read_u8("user_custom")
+        self.capacity = read_u16("full_capacity") / 100
+        self.capacity_remain = read_u16("remaining_capacity") / 100
+        self.history.charge_cycles = read_u16("charge_cycles")
+
+        voltagestatus = read_u16("voltage_status")
+        currentstatus = read_u16("current_status")
+        temperaturestatus = read_u16("temperature_status")
+        warningstatus = read_u16("warning_status")
+        fetstatus = read_u16("fet_status")
+
+        # Per-cell LOW status masks. They are not exposed individually by the
+        # framework, but precede the balance masks in the manufacturer parser.
+        read_u16("cell_overvoltage_protection_low")
+        read_u16("cell_undervoltage_protection_low")
+        read_u16("cell_overvoltage_alarm_low")
+        read_u16("cell_undervoltage_alarm_low")
+
+        # Balance LOW = cells 1..16, Balance HIGH = cells 17..32.
+        # The vendor implementation enumerates bits LSB-first, i.e. bit 0 = cell 1.
+        balance_low = read_u16("cell_balance_low")
+        balance_high = read_u16("cell_balance_high")
+        balance_mask = balance_low | (balance_high << 16)
+
+        # Service 0x42 reports short balancing pulses. Assert balancing immediately,
+        # but keep the global and per-cell states active until the raw bit has
+        # remained clear continuously for BALANCE_OFF_DELAY_SECONDS.
+        self._update_balancing_status(balance_mask)
+        self._log_balance_status(balance_mask)
+
+        logger.debug(
+            "KS48100 realtime: cells={}, temp_sensors={}, ambient={}C, pack={}C, "
+            "MOS={}C, internal_resistance={}, user_custom={}, balance=0x{:08X}".format(
+                self.cell_count,
+                temperature_count,
+                temperature_ambient,
+                temperature_pack,
+                temperature_mos,
+                pack_internal_resistance,
+                user_custom,
+                balance_mask,
+            )
+        )
+
+        return voltagestatus, currentstatus, temperaturestatus, warningstatus, fetstatus
 
     def get_realtime_data(self, ser):
         """
@@ -273,29 +405,8 @@ class KS48100(Battery):
 
         if response:
             payload = response[13 : len(response) - 5]
-            if len(payload) >= 152:
-                self.soc = int(payload[2:6], base=16) / 100
-                self.soh = int(payload[114:118], base=16) / 1
-                self.voltage = int(payload[6:10], base=16) / 100
-                self.current = unpack(">h", bytes.fromhex(payload[106:110]))[0] / 100
-                temperature_mos = unpack(">h", bytes.fromhex(payload[84:88]))[0] / 10
-                self.to_temperature(0, temperature_mos)
-                temperature_1 = unpack(">h", bytes.fromhex(payload[90:94]))[0] / 10
-                self.to_temperature(1, temperature_1)
-                temperature_2 = unpack(">h", bytes.fromhex(payload[94:98]))[0] / 10
-                self.to_temperature(2, temperature_2)
-                temperature_3 = unpack(">h", bytes.fromhex(payload[98:102]))[0] / 10
-                self.to_temperature(3, temperature_3)
-                temperature_4 = unpack(">h", bytes.fromhex(payload[102:106]))[0] / 10
-                self.to_temperature(4, temperature_4)
-                self.capacity = int(payload[120:124], base=16) / 100
-                self.capacity_remaining = int(payload[124:128], base=16) / 100
-                self.history.charge_cycles = int(payload[128:132], base=16)
-                voltagestatus = int(payload[132:136], base=16)
-                currentstatus = int(payload[136:140], base=16)
-                temperaturestatus = int(payload[140:144], base=16)
-                warningstatus = int(payload[144:148], base=16)
-                fetstatus = int(payload[148:152], base=16)
+            try:
+                voltagestatus, currentstatus, temperaturestatus, warningstatus, fetstatus = self._parse_realtime_payload(payload)
 
                 # check bit 2 for TOT_OVV_PROT and bit 0 for cell_OVV_PROT
                 if voltagestatus & (1 << 2) or voltagestatus & (1 << 0):
@@ -361,11 +472,10 @@ class KS48100(Battery):
                 else:
                     self.protection.cell_imbalance = 0
 
-                # if something else is in warning, report internal failure. warningstatus
-                # contains all sorts of internal components, such as CHG_FET, NTC_fail,
-                # cell_fail, chg_mos_fail, disch_mos_fail, etc.
-                # Ignore V_DIF_alarm and low_BAT_alarm flags, since we're allready checking for those.
-                if (warningstatus & 0b01111110) > 0:
+                # warningstatus contains component failure flags in bits 1..6 and
+                # 9..15. Exclude bit 7 (low battery) and bit 8 (MOS high-temp
+                # protection), which have dedicated meanings.
+                if warningstatus & 0xFE7E:
                     self.protection.internal_failure = 2
                 else:
                     self.protection.internal_failure = 0
@@ -433,17 +543,137 @@ class KS48100(Battery):
                     self.discharge_fet = False
                     self.max_battery_discharge_current = 0
 
-                for i in range(1, 17):
-                    cell_voltage = int(payload[(i - 1) * 4 + 12 : i * 4 + 12], base=16) / 1000
-                    self.cells[i - 1].voltage = cell_voltage
-
                 result = True
-            else:
-                logger.error("get_realtime_data response length error!")
+
+            except (ValueError, TypeError) as e:
+                logger.error("get_realtime_data response parsing error: {}".format(e))
+                logger.debug("get_realtime_data payload: {}".format(payload))
         else:
             logger.error("get_realtime_data response error!")
 
         return result
+
+    def _update_balancing_status(self, balance_mask):
+        """
+        Debounce the OFF state of the pulsed Service 0x42 balancing bits.
+
+        A reported active bit is applied immediately. Once the raw bit clears, the
+        corresponding cell and aggregate balance states remain active until the bit
+        has stayed clear continuously for BALANCE_OFF_DELAY_SECONDS.
+        """
+        now = monotonic()
+
+        for i in range(self.cell_count):
+            raw_active = bool(balance_mask & (1 << i))
+
+            if raw_active:
+                self.cells[i].balance = True
+                self._cell_balance_off_since.pop(i, None)
+            elif self.cells[i].balance:
+                off_since = self._cell_balance_off_since.get(i)
+                if off_since is None:
+                    self._cell_balance_off_since[i] = now
+                elif now - off_since >= self.BALANCE_OFF_DELAY_SECONDS:
+                    self.cells[i].balance = False
+                    self._cell_balance_off_since.pop(i, None)
+            else:
+                self._cell_balance_off_since.pop(i, None)
+
+        if balance_mask != 0:
+            self.balance_fet = True
+            self._balance_fet_off_since = None
+        elif self.balance_fet:
+            if self._balance_fet_off_since is None:
+                self._balance_fet_off_since = now
+            elif now - self._balance_fet_off_since >= self.BALANCE_OFF_DELAY_SECONDS:
+                self.balance_fet = False
+                self._balance_fet_off_since = None
+        else:
+            if self.balance_fet is None:
+                self.balance_fet = False
+            self._balance_fet_off_since = None
+
+    def _log_balance_status(self, balance_mask=None):
+        """Debug-log balancing state on first observation and whenever mode or mask changes."""
+        if balance_mask is not None:
+            self._last_balance_mask = balance_mask
+
+        if self._last_balance_mask is None:
+            return
+
+        status = (self.balanced_mode, self._last_balance_mask)
+        if status == self._last_balance_status:
+            return
+
+        active_cells = [str(i + 1) for i in range(self.cell_count) if self._last_balance_mask & (1 << i)]
+        active_cells_text = ",".join(active_cells) if active_cells else "none"
+        mode_text = str(self.balanced_mode) if self.balanced_mode is not None else "unknown"
+
+        logger.debug(
+            "BALANCE STATUS: mode={} | mask=0x{:08X} | active cells: {}".format(
+                mode_text,
+                self._last_balance_mask,
+                active_cells_text,
+            )
+        )
+        self._last_balance_status = status
+
+    def get_balance_params(self, ser):
+        """
+        Read balancing configuration once at startup using Service 0x80.
+
+        The manufacturer parser stores these four values as 16-bit fields:
+        balance high temperature, balance low temperature (signed),
+        balance starting voltage and balance starting voltage difference.
+        """
+        req = self.create_command_get_balance_params()
+
+        ser.flushOutput()
+        ser.flushInput()
+        ser.write(req.encode())
+        capture_raw_data(ser.port, "tx", req)
+        logger.debug("get_balance_params request sent: {}".format(req))
+
+        # Service 0x80 returns a comparatively long response. At 9600 baud it needs
+        # roughly half a second on the wire, so leave some margin before reading.
+        sleep(0.8)
+
+        response = self.read_response(ser)
+
+        if not response:
+            logger.warning("get_balance_params response error; Service 0x80 may not be supported")
+            return False
+
+        payload = response[13 : len(response) - 5]
+
+        # In the manufacturer Service 0x80 parser these are fields 99..102
+        # (zero-based indices 98..101), each encoded as two bytes / four hex chars.
+        if len(payload) < 408:
+            logger.warning("get_balance_params response too short: {} chars, expected at least 408".format(len(payload)))
+            logger.debug("get_balance_params payload: {}".format(payload))
+            return False
+
+        try:
+            balance_high_temp = int(payload[392:396], base=16)
+            balance_low_temp = unpack(">h", bytes.fromhex(payload[396:400]))[0]
+            balance_start_voltage_raw = int(payload[400:404], base=16)
+            balance_start_diff_raw = int(payload[404:408], base=16)
+        except (ValueError, TypeError) as e:
+            logger.warning("get_balance_params response parsing error: {}".format(e))
+            logger.debug("get_balance_params payload: {}".format(payload))
+            return False
+
+        # Voltage values are reported by these BMS in mV; temperature values are °C.
+        logger.info(
+            "> BALANCE PARAMS: High temp: {} C | Low temp: {} C | "
+            "Start voltage: {:.3f} V | Start difference: {} mV".format(
+                balance_high_temp,
+                balance_low_temp,
+                balance_start_voltage_raw / 1000,
+                balance_start_diff_raw,
+            )
+        )
+        return True
 
     def get_manufacturer_info(self, ser):
         """
@@ -527,13 +757,18 @@ class KS48100(Battery):
                 CHG_C_limit = int(int(payload[34:38], base=16) / 100)
                 # design_capacity_none = int(payload[38:42], base=16) / 100
                 # historical_data_storage_interval = int(payload[42:46], base=16)
-                # balanced_mode = int(payload[46:50], base=16)
+                balanced_mode = int(payload[46:50], base=16)
                 # product_barcode_byte_array = bytearray.fromhex(payload[50:90])
                 # product_barcode = product_barcode_byte_array.decode()
                 # BMS_barcode_byte_array = bytearray.fromhex(payload[90:130])
                 # BMS_barcode = BMS_barcode_byte_array.decode()
 
                 self.cell_count = num_of_cells
+                # Service 0x47 balanced_mode is retained as a raw/configuration mode.
+                # Hardware testing proved that value 0 does not mean balancing disabled:
+                # Service 0x42 can report active cell balancing while balanced_mode is 0.
+                self.balanced_mode = balanced_mode
+                self._log_balance_status()
                 if self.charge_fet is True:
                     self.max_battery_charge_current = CHG_C_limit
                 else:
@@ -612,6 +847,12 @@ class KS48100(Battery):
 
         logger.debug("read_response Data valid!")
         return buff
+
+    def create_command_get_balance_params(self):
+        """
+        Generates the read-only Service 0x80 request used by the manufacturer application.
+        """
+        return self.create_command(self.address, b"\x42", b"\x80", self.address.hex().upper())
 
     def create_command_get_cells_params(self):
         """

--- a/tests/bms/test_daren_ks.py
+++ b/tests/bms/test_daren_ks.py
@@ -198,15 +198,7 @@ def test_ks_low_battery_warning_is_not_internal_failure(monkeypatch):
 
 def test_ks_get_cap_params_uses_framework_capacity_remain(monkeypatch):
     bms = _make_ks()
-    payload = (
-        _u16(7550)
-        + _u16(10000)
-        + _u16(10000)
-        + "00000064"
-        + "00000032"
-        + _u16(1234)
-        + _u16(567)
-    )
+    payload = _u16(7550) + _u16(10000) + _u16(10000) + "00000064" + "00000032" + _u16(1234) + _u16(567)
     response = ("0" * 25) + payload + ("0" * 5)
     monkeypatch.setattr(bms, "read_response", lambda _ser: response)
 

--- a/tests/bms/test_daren_ks.py
+++ b/tests/bms/test_daren_ks.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for the Daren485 and KS48100 protocol changes."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "..", "dbus-serialbattery"),
+)
+
+from battery import Cell  # noqa: E402
+from bms.daren_485 import Daren485  # noqa: E402
+from bms.ks48100 import KS48100  # noqa: E402
+import bms.daren_485 as daren_module  # noqa: E402
+import bms.ks48100 as ks_module  # noqa: E402
+
+
+def _u8(value):
+    return f"{value & 0xFF:02X}"
+
+
+def _u16(value):
+    return f"{value & 0xFFFF:04X}"
+
+
+def _i16(value):
+    return _u16(value)
+
+
+def build_realtime_payload(
+    cell_count=16,
+    temperature_count=4,
+    balance_low=0,
+    balance_high=0,
+    warning_status=0,
+):
+    parts = [
+        _u8(1),
+        _u16(7550),
+        _u16(5260),
+        _u8(cell_count),
+    ]
+    parts.extend(_u16(3300 + i) for i in range(cell_count))
+    parts.extend(
+        [
+            _i16(250),
+            _i16(260),
+            _i16(270),
+            _u8(temperature_count),
+        ]
+    )
+    parts.extend(_i16(280 + (i * 10)) for i in range(temperature_count))
+    parts.extend(
+        [
+            _i16(-123),
+            _u16(12),
+            _u16(99),
+            _u8(0),
+            _u16(10000),
+            _u16(7500),
+            _u16(123),
+            _u16(0),
+            _u16(0),
+            _u16(0),
+            _u16(warning_status),
+            _u16(3),
+            _u16(0),
+            _u16(0),
+            _u16(0),
+            _u16(0),
+            _u16(balance_low),
+            _u16(balance_high),
+        ]
+    )
+    return "".join(parts)
+
+
+class FakeSerial:
+    port = "/dev/mock"
+
+    def __init__(self):
+        self.written = []
+
+    def flushOutput(self):
+        pass
+
+    def flushInput(self):
+        pass
+
+    def write(self, value):
+        self.written.append(value)
+
+
+def _frame(payload):
+    return ("0" * 13) + payload + ("0" * 5)
+
+
+def _make_daren(cell_count=16):
+    bms = Daren485("/dev/mock", 9600, b"\x01")
+    bms.cell_count = cell_count
+    bms.cells = [Cell(False) for _ in range(cell_count)]
+    return bms
+
+
+def _make_ks(cell_count=16):
+    bms = KS48100("/dev/mock", 9600, b"\x01")
+    bms.cell_count = cell_count
+    bms.cells = [Cell(False) for _ in range(cell_count)]
+    return bms
+
+
+@pytest.fixture(autouse=True)
+def no_protocol_sleep(monkeypatch):
+    monkeypatch.setattr(daren_module, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(ks_module, "sleep", lambda _seconds: None)
+
+
+def test_daren_realtime_balance_mask_and_values(monkeypatch):
+    bms = _make_daren()
+    payload = build_realtime_payload(balance_low=0x0005)
+    monkeypatch.setattr(bms, "read_response", lambda _ser: _frame(payload))
+
+    assert bms.get_realtime_data(FakeSerial()) is True
+    assert bms.cell_count == 16
+    assert len(bms.cells) == 16
+    assert bms.cells[0].balance is True
+    assert bms.cells[1].balance is False
+    assert bms.cells[2].balance is True
+    assert bms.balance_fet is True
+    assert bms.soc == 75.5
+    assert bms.voltage == 52.6
+    assert bms.current == -1.23
+    assert bms.soh == 99
+    assert bms.capacity == 100
+    assert bms.capacity_remain == 75
+
+
+def test_daren_rejects_runtime_cell_count_change(monkeypatch):
+    bms = _make_daren(cell_count=16)
+    payload = build_realtime_payload(cell_count=15)
+    monkeypatch.setattr(bms, "read_response", lambda _ser: _frame(payload))
+
+    assert bms.get_realtime_data(FakeSerial()) is False
+    assert bms.cell_count == 16
+    assert len(bms.cells) == 16
+
+
+def test_ks_realtime_balance_mask_and_values():
+    bms = _make_ks()
+    payload = build_realtime_payload(balance_low=0x0005)
+
+    status = bms._parse_realtime_payload(payload)
+
+    assert status == (0, 0, 0, 0, 3)
+    assert bms.cells[0].balance is True
+    assert bms.cells[1].balance is False
+    assert bms.cells[2].balance is True
+    assert bms.balance_fet is True
+    assert bms.soc == 75.5
+    assert bms.voltage == 52.6
+    assert bms.current == -1.23
+    assert bms.soh == 99
+    assert bms.capacity == 100
+    assert bms.capacity_remain == 75
+
+
+def test_ks_rejects_runtime_cell_count_change():
+    bms = _make_ks(cell_count=16)
+    payload = build_realtime_payload(cell_count=15)
+
+    with pytest.raises(ValueError, match="differs from configured cell count"):
+        bms._parse_realtime_payload(payload)
+
+    assert bms.cell_count == 16
+    assert len(bms.cells) == 16
+
+
+def test_ks_internal_failure_uses_upper_warning_bits(monkeypatch):
+    bms = _make_ks()
+    payload = build_realtime_payload(warning_status=(1 << 9))
+    monkeypatch.setattr(bms, "read_response", lambda _ser: _frame(payload))
+
+    assert bms.get_realtime_data(FakeSerial()) is True
+    assert bms.protection.internal_failure == 2
+
+
+def test_ks_low_battery_warning_is_not_internal_failure(monkeypatch):
+    bms = _make_ks()
+    payload = build_realtime_payload(warning_status=(1 << 7))
+    monkeypatch.setattr(bms, "read_response", lambda _ser: _frame(payload))
+
+    assert bms.get_realtime_data(FakeSerial()) is True
+    assert bms.protection.internal_failure == 0
+
+
+def test_ks_get_cap_params_uses_framework_capacity_remain(monkeypatch):
+    bms = _make_ks()
+    payload = (
+        _u16(7550)
+        + _u16(10000)
+        + _u16(10000)
+        + "00000064"
+        + "00000032"
+        + _u16(1234)
+        + _u16(567)
+    )
+    response = ("0" * 25) + payload + ("0" * 5)
+    monkeypatch.setattr(bms, "read_response", lambda _ser: response)
+
+    assert bms.get_cap_params(FakeSerial()) is True
+    assert bms.capacity_remain == 75
+    assert not hasattr(bms, "capacity_remaining")


### PR DESCRIPTION
Improve variable-length Service 0x42 parsing and read-only balancing status for Daren485/KS48100, add safe runtime validation, KS capacity/warning fixes, 10-second off-delay for pulsed balance reporting, read-only Service 0x80 diagnostics, and regression tests.