### PR TITLE
Guard charge_mode against None in the float transition arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * Changed: Fixed problems with the `BLOCK_ON_DISCONNECT` behavior. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/309 by @mr-manuel
 * Changed: Fixed SOC manual reset via GUI having no effect when `SOC_CALCULATION` is enabled by @mr-manuel
 * Changed: Fixed typo in activation instructions by @mr-manuel
+* Changed: Guard `charge_mode` against `None` in `manage_charge_voltage_limit()`. It is declared as `str` but initialised to `None`, and the float branch tests it twice: the first arm checks for `None`, the second does not, so a `None` fails the first check and is dereferenced by the second. The surrounding handler only catches `TypeError`, so the resulting `AttributeError` leaves the method by @cgoudie
 * Changed: Guard voltage and current limit assignments with `USE_BMS_DVCC_VALUES`; replace hardcoded limits with `MAX_CELL_VOLTAGE`, `MAX_BATTERY_CHARGE_CURRENT`, and `MAX_BATTERY_DISCHARGE_CURRENT` config constants. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/454 by @mr-manuel
 * Changed: GUI clearing of CustomName was silently ignored — `callback_custom_name` returned the new value, which is falsy for the empty string and caused VeDbusService to reject the write while `set_settings` had already persisted it; callback now returns truthy on success by @hsteinhaus
 * Changed: GUIv2 - With Venus OS `v3.80~21` GUIv2 plugins are used instead of fully customized GUI by @mr-manuel

--- a/dbus-serialbattery/battery.py
+++ b/dbus-serialbattery/battery.py
@@ -938,7 +938,7 @@ class Battery(ABC):
                             self.soc_calc_capacity_remain = self.capacity
                             self.soc_calc_reset_start_time = None
 
-                    elif self.charge_mode.startswith("Float Transition"):
+                    elif self.charge_mode is not None and self.charge_mode.startswith("Float Transition"):
                         elapsed_time = current_time - self.transition_start_time
                         # Voltage reduction per second
                         voltage_reduction = min(

--- a/tests/test_charge_mode_none_guard.py
+++ b/tests/test_charge_mode_none_guard.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Tests that manage_charge_voltage_limit() survives charge_mode being None.
+
+battery.py declares ``self.charge_mode: str = None``, so None is a value the
+attribute really takes. The float branch has two arms testing it: the first is
+guarded, which means a None fails that test and is delivered straight to the
+second one. The exception handler around the whole method catches TypeError
+only, so an AttributeError raised there leaves the method entirely.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "dbus-serialbattery"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "dbus-serialbattery", "ext", "velib_python"))
+
+import pytest  # noqa: E402
+import utils  # noqa: E402
+from battery import Battery  # noqa: E402
+
+
+class StubBattery(Battery):
+    """Concrete Battery, so it can be instantiated. No BMS communication."""
+
+    def test_connection(self) -> bool:
+        return True
+
+    def get_settings(self) -> bool:
+        return True
+
+    def refresh_data(self) -> bool:
+        return True
+
+
+def _battery_in_float_mode(charge_mode):
+    """A battery on the float branch, with charge_mode set by the caller.
+
+    allow_max_voltage False selects the float branch, and control_voltage being
+    set opens the gate in front of the two arms that read charge_mode.
+    """
+    battery = StubBattery("/dev/null", 9600, None)
+
+    battery.cell_count = 16
+    battery.max_battery_voltage = 56.8
+    battery.control_voltage = 55.2
+    battery.charge_mode = charge_mode
+
+    # take the float branch and stay on it
+    battery.allow_max_voltage = False
+    battery.max_voltage_start_time = None
+    battery.soc_calc = 100
+    battery.soc_reset_requested = False
+    battery.soc_reset_last_reached = 0
+
+    # balanced cells, below max voltage: no switch back to bulk
+    battery.get_cell_voltage_sum = lambda: 53.0
+    battery.get_max_cell_voltage = lambda: 3.35
+    battery.get_min_cell_voltage = lambda: 3.33
+
+    return battery
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_config(monkeypatch):
+    """Pin the settings that steer the branch, so config.ini cannot change the test."""
+    monkeypatch.setattr(utils, "SWITCH_TO_BULK_SOC_THRESHOLD", 0)
+    monkeypatch.setattr(utils, "SWITCH_TO_BULK_CELL_VOLTAGE_DIFF", 10)
+    monkeypatch.setattr(utils, "SWITCH_TO_FLOAT_CELL_VOLTAGE_DIFF", 10)
+    monkeypatch.setattr(utils, "FLOAT_CELL_VOLTAGE", 3.375)
+    monkeypatch.setattr(utils, "SOC_CALCULATION", False)
+
+
+def test_none_charge_mode_does_not_raise():
+    """The regression: None reaches the second arm and must not be dereferenced."""
+    battery = _battery_in_float_mode(None)
+
+    battery.manage_charge_voltage_limit()
+
+    # completing the branch proves it ran past the arms rather than escaping
+    assert battery.charge_mode.startswith("Float")
+
+
+def test_none_charge_mode_error_is_not_caught_by_the_handler():
+    """The method only catches TypeError, so an AttributeError here would escape.
+
+    Guards the reason this matters: without the fix the failure is not the
+    "Non blocking exception" the handler reports, it leaves the method.
+    """
+    battery = _battery_in_float_mode(None)
+
+    battery.manage_charge_voltage_limit()
+
+    # the handler sets this string when it swallows a TypeError; reaching a real
+    # Float mode instead shows nothing was raised and swallowed on the way
+    assert battery.charge_mode != "Error, please check the logs!"
+    assert battery.charge_mode.startswith("Float")
+
+
+def test_float_transition_arm_still_runs():
+    """The guard must not disable the arm it protects."""
+    battery = _battery_in_float_mode("Float Transition")
+    battery.transition_start_time = 0
+    battery.initial_control_voltage = 55.2
+
+    battery.manage_charge_voltage_limit()
+
+    assert battery.charge_mode.startswith("Float")
+
+
+def test_bulk_charge_mode_takes_the_first_arm():
+    """A non-None charge_mode not starting with Float still enters the transition."""
+    battery = _battery_in_float_mode("Bulk")
+
+    battery.manage_charge_voltage_limit()
+
+    assert battery.charge_mode.startswith("Float Transition")


### PR DESCRIPTION
### The defect

`battery.py:358` declares `self.charge_mode: str = None`. The declared type says `str`, the initialiser says `None`, so `None` is a value the attribute really takes.

The float branch reads it twice, in two arms of the same `if`/`elif` chain:

```python
# battery.py:917
if self.charge_mode is not None and not self.charge_mode.startswith("Float"):
    ...
# battery.py:941
elif self.charge_mode.startswith("Float Transition"):
```

The first arm is guarded. The second is not. So when `charge_mode` is `None` the first test evaluates false — *because of its own guard* — and control falls to the second arm, which dereferences it. Guarding one arm is precisely what delivers the `None` to the other.

One line: the same `is not None` check on `:941`.

### Why this is not just a defensive check

The `try` wrapping `manage_charge_voltage_limit()` catches **`TypeError` only** (`battery.py:1056`). `None.startswith(...)` raises `AttributeError`, which that handler does not catch. So this failure is not turned into the "Non blocking exception occurred" the method logs for its other error paths — it leaves the method.

### Scope: why one line and not three

`:961` and `:963` do `self.charge_mode += ...` and need no guard. The `if`/`else` at `:773` / `:905` is exhaustive, and both arms assign `charge_mode` unconditionally before those lines — `:845` in the bulk/absorption arm, `:958` in the float arm.

A `grep` for `charge_mode\.` also surfaces `:970`. That line is inside the triple-quoted block at `:965`-`:975` and is not executed. Mentioning it so a reviewer running the same grep doesn't have to re-derive it.

### On reproducing it

**No stock reproduction is claimed.** On stock code the first cycle takes the `:773` arm — `allow_max_voltage` defaults to `True` — and assigns `charge_mode` at `:845` before the float arm can ever run. The crash we saw in the field came through a downstream consumer that set the attribute back to `None`, which is our own code and is fixed on our side.

The guard is here because the declared type permits `None`, one arm of the chain already anticipates it, and the handler cannot absorb the result if it happens.

### Tests

`tests/test_charge_mode_none_guard.py`, four cases: `None` on the float branch completes instead of raising; the same case does not trip the `TypeError` handler's error string; the `Float Transition` arm still runs when it should; a non-`None` mode not starting with `Float` still enters the transition.

Checked by mutation rather than by passing — reverting the one-line guard fails two of the four with:

```
E   AttributeError: 'NoneType' object has no attribute 'startswith'
dbus-serialbattery/battery.py:941: AttributeError
```

which is the field traceback.

The tests pin the settings that steer the branch via `monkeypatch`, so a local `config.ini` cannot change what they exercise.

`black --check` and `flake8` clean. Locally on macOS `pytest` reports 18 failures and 28 errors both with and without this branch — pre-existing and unrelated; this adds 4 passing tests and changes neither count.

### Checked and deliberately not changed

`bms/daly.py:179` and `bms/daly_can.py:524` come up in the same grep and look like the same defect. **They are already guarded** — `:178` and `:523` respectively test both `last_charge_mode` and `charge_mode` for `None` before the dereference. No change needed there.
