### PR TITLE
Reduce the log noise of a stalled battery connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 * Changed: D-bus charge limits - Skip None writes to `/Info/MaxChargeCurrent` and `/Info/MaxDischargeCurrent` so consumers like `dbus-aggregate-batteries` don't crash with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'` during the brief window before the first charge-control decision lands by @hsteinhaus
 * Changed: Daly BMS & Daly CAN BMS: Fix high charge/discharge current alarm. Fixes https://github.com/mr-manuel/venus-os_dbus-serialbattery/issues/378 by @mr-manuel
 * Changed: Daren 485 BMS - Fixed charge/discharge calculation with https://github.com/mr-manuel/venus-os_dbus-serialbattery/pull/343 by @kopierschnitte
+* Changed: dbus-serialbattery.py - Rate limit the "Polling took ..." warning to once per 60 seconds and suppress it entirely while a battery is known to be offline. A stalled connection makes every poll a slow poll, so the warning was logged once per cycle for the whole outage, next to the disconnect that `dbushelper` already reports for the same event by @cgoudie
+* Changed: dbushelper.py - Condense the cell voltage threshold report logged when a battery stops responding from three lines to one, with the measured and configured voltages inline by @cgoudie
 * Changed: dbushelper.py - Ensure loading of newest battery data if more than one duplicate exists by @lex2k0
 * Changed: dbushelper.py - Refresh the `LastSeen` setting daily while the driver is running. Previously it was written only at startup, so after more than 30 days of continuous uptime a restart deleted the settings (device instance, custom name, history) of all other batteries sharing the port by @dmitrych5
 * Changed: dbushelper.py - Reworked save settings methods by @lex2k0

--- a/dbus-serialbattery/dbus-serialbattery.py
+++ b/dbus-serialbattery/dbus-serialbattery.py
@@ -5,7 +5,7 @@ import os
 import signal
 import sys
 from datetime import datetime
-from time import sleep
+from time import sleep, time
 from typing import Union
 
 from dbus.mainloop.glib import DBusGMainLoop
@@ -120,6 +120,35 @@ if CAPTURE_RAW_DATA:
 count_for_loops = 5
 delayed_loop_count = 0
 
+# rate limit for the slow poll warning, since a stalled connection triggers it every cycle
+poll_warning_interval = 60
+poll_warning_last_time = 0
+
+
+def should_log_poll_warning(batteries, current_time: int) -> bool:
+    """
+    Check whether the slow poll warning should be logged now.
+
+    A poll that waits on a battery which is already known to be offline is that outage,
+    not a second fault, and the offline state is reported by the dbushelper. Otherwise the
+    warning is rate limited, since a stalled connection makes every cycle a slow one.
+
+    :param batteries: the battery objects of this process
+    :param current_time: current time in seconds
+    :return: True if the warning should be logged, False if it should be suppressed
+    """
+    global poll_warning_last_time
+
+    # online is None until the first successful poll, so a slow start is still reported
+    if any(battery.online is False for battery in batteries):
+        return False
+
+    if current_time - poll_warning_last_time < poll_warning_interval:
+        return False
+
+    poll_warning_last_time = current_time
+    return True
+
 
 def main():
     global expected_bms_types, supported_bms_types
@@ -195,7 +224,8 @@ def main():
             delayed_loop_count += 1
             if delayed_loop_count > 1:
                 remaining = count_for_loops - delayed_loop_count
-                logger.warning(f"Polling took {runtime:.3f}s (refresh {refresh_runtime:.3f}s). Increase in {remaining} cycles.")
+                if should_log_poll_warning(battery.values(), int(time())):
+                    logger.warning(f"Polling took {runtime:.3f}s (refresh {refresh_runtime:.3f}s). Increase in {remaining} cycles.")
         else:
             delayed_loop_count = 0
 

--- a/dbus-serialbattery/dbushelper.py
+++ b/dbus-serialbattery/dbushelper.py
@@ -1061,22 +1061,13 @@ class DbusHelper:
                             )
 
                             if not utils.BLOCK_ON_DISCONNECT:
+                                min_cell_voltage = self.battery.get_min_cell_voltage()
+                                max_cell_voltage = self.battery.get_max_cell_voltage()
                                 logger.error(
-                                    "    |- Cell voltages are"
-                                    + ("" if self.cell_voltages_good else " NOT")
-                                    + " in a safe threshold to proceed with charging/discharging without communication to the battery."
-                                )
-                                logger.error(
-                                    "    |- "
-                                    + f"Min cell voltage: {self.battery.get_min_cell_voltage():.3f} > "
-                                    + f"Min Threshold: {utils.BLOCK_ON_DISCONNECT_VOLTAGE_MIN:.3f} --> "
-                                    + ("OK" if self.battery.get_min_cell_voltage() > utils.BLOCK_ON_DISCONNECT_VOLTAGE_MIN else "NOT OK")
-                                )
-                                logger.error(
-                                    "    |- "
-                                    + f"Max cell voltage: {self.battery.get_max_cell_voltage():.3f} < "
-                                    + f"Max threshold: {utils.BLOCK_ON_DISCONNECT_VOLTAGE_MAX:.3f} --> "
-                                    + ("OK" if self.battery.get_max_cell_voltage() < utils.BLOCK_ON_DISCONNECT_VOLTAGE_MAX else "NOT OK")
+                                    f"    |- Cell voltages are{'' if self.cell_voltages_good else ' NOT'} in a safe threshold to proceed"
+                                    + " without communication to the battery: "
+                                    + f"min {min_cell_voltage:.3f} V (> {utils.BLOCK_ON_DISCONNECT_VOLTAGE_MIN:.3f} V), "
+                                    + f"max {max_cell_voltage:.3f} V (< {utils.BLOCK_ON_DISCONNECT_VOLTAGE_MAX:.3f} V)"
                                 )
 
                             self.battery.init_values()

--- a/tests/test_poll_warning_rate_limit.py
+++ b/tests/test_poll_warning_rate_limit.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Tests for the rate limiting of the slow poll warning.
+
+A stalled battery connection makes every poll a slow poll, so the warning fired
+once per cycle for as long as the outage lasted, alongside the dbushelper's own
+report of the same outage.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+DRIVER_DIR = os.path.join(os.path.dirname(__file__), "..", "dbus-serialbattery")
+sys.path.insert(0, DRIVER_DIR)
+sys.path.insert(0, os.path.join(DRIVER_DIR, "ext", "velib_python"))
+
+import pytest  # noqa: E402
+
+# conftest registers bare stubs for the Linux-only D-Bus modules. Complete the attributes
+# this module imports, instead of registering a stub that setdefault() would discard.
+_glib_mainloop = sys.modules.setdefault("dbus.mainloop.glib", types.ModuleType("dbus.mainloop.glib"))
+
+if not hasattr(_glib_mainloop, "DBusGMainLoop"):
+    _glib_mainloop.DBusGMainLoop = lambda **kwargs: None
+
+
+def _load_driver_module():
+    """Import dbus-serialbattery.py, whose file name is not a valid module name."""
+    path = os.path.join(DRIVER_DIR, "dbus-serialbattery.py")
+    spec = importlib.util.spec_from_file_location("dbus_serialbattery_main", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = _load_driver_module()
+
+
+def _battery(online):
+    return types.SimpleNamespace(online=online)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit():
+    """The timestamp is module state, so each test has to start from a known point."""
+    driver.poll_warning_last_time = 0
+    yield
+    driver.poll_warning_last_time = 0
+
+
+def test_first_slow_poll_is_reported():
+    assert driver.should_log_poll_warning([_battery(True)], 1000) is True
+
+
+def test_second_slow_poll_within_the_interval_is_suppressed():
+    """The regression: one warning per cycle for the whole outage."""
+    assert driver.should_log_poll_warning([_battery(True)], 1000) is True
+
+    for offset in range(1, driver.poll_warning_interval):
+        assert driver.should_log_poll_warning([_battery(True)], 1000 + offset) is False
+
+
+def test_warning_returns_after_the_interval():
+    """Rate limited, not silenced: a persisting problem is still reported."""
+    assert driver.should_log_poll_warning([_battery(True)], 1000) is True
+
+    assert driver.should_log_poll_warning([_battery(True)], 1000 + driver.poll_warning_interval) is True
+
+
+def test_offline_battery_suppresses_the_warning():
+    """The dbushelper already reports the outage; the slow poll is that outage."""
+    assert driver.should_log_poll_warning([_battery(False)], 1000) is False
+
+
+def test_one_offline_battery_suppresses_it_for_the_process():
+    """The poll is a single loop over all batteries, so one dead link delays all of them."""
+    assert driver.should_log_poll_warning([_battery(True), _battery(False)], 1000) is False
+
+
+def test_battery_that_has_never_polled_does_not_suppress_it():
+    """online is None before the first successful poll, and a slow start is worth reporting."""
+    assert driver.should_log_poll_warning([_battery(None)], 1000) is True
+
+
+def test_suppressed_warning_does_not_start_the_interval():
+    """An outage must not delay the first warning after recovery."""
+    assert driver.should_log_poll_warning([_battery(False)], 1000) is False
+
+    assert driver.should_log_poll_warning([_battery(True)], 1001) is True


### PR DESCRIPTION
A battery whose connection stalls currently produces two reports of the same event, and one of them repeats every cycle.

### The repeating one

`dbus-serialbattery.py:198` warns `Polling took ...` when a poll takes longer than the poll interval. During an outage the poll is slow **because** it is waiting on the dead connection, so the warning is logged once per poll interval for the entire outage — next to the disconnect that `dbushelper` already reports for the same underlying event.

Two changes, doing different jobs:

- **Suppressed while a battery is known offline.** `battery.online` goes `False` once a battery has not updated for `RETRY_CYCLE_SHORT_COUNT` seconds (`dbushelper.py:1049`), which is also where the outage gets its own ERROR. Warning about the slow poll on top of that describes one fault twice. This is what silences a sustained outage completely.
- **Rate limited to once per 60 s otherwise.** `online` is `False` only after that threshold, so the first seconds of an outage — and any slow poll with no outage behind it at all — still warn, just not once per cycle. The information is kept, the repetition is not.

`online` is `None`, not `False`, until the first successful poll, so a slow start is still reported.

If you watch logs for these lines: the text is unchanged, only how often it appears. Note that there are two similar warnings and this touches one of them — `Polling took too long for the last N cycles. Set to ...` (`dbus-serialbattery.py:241`), logged when the poll interval is actually raised, is untouched and still fires every time it happens.

The decision moved into a module-level `should_log_poll_warning()`. `poll_battery()` is nested inside `main()` and cannot be reached from a test, and I would rather this behaviour were testable than save the six lines.

### The three-line one

When a battery stops responding, `dbushelper.py` logs the ERROR plus a three-line checklist of the cell voltage thresholds. That is one line now, with the measured and configured voltages inline:

```
>>> ERROR: Battery does not respond, init/reset values <<<
    BLOCK_ON_DISCONNECT is disabled. Exit in 60 seconds if recovery does not occur.
    |- Cell voltages are in a safe threshold to proceed without communication to the battery: min 3.312 V (> 3.100 V), max 3.339 V (< 3.450 V)
```

Level and content are unchanged — this is the genuine exit path and should stay loud. It also now reads each cell voltage once instead of twice.

### Deliberately not changed

`>>> Battery reconnected <<<` (`dbushelper.py:971`) stays as it is. It fires once per recovery, not per cycle, and INFO is right for it.

### Tests

`tests/test_poll_warning_rate_limit.py`, seven cases: the first slow poll warns; every subsequent one inside the interval does not; the warning returns after the interval, so a persisting problem is still reported; an offline battery suppresses it; one offline battery among several suppresses it for the process, since the poll is a single loop over all of them; a battery that has never polled does not suppress it; and a suppressed warning does not consume the interval, so recovery is not followed by 60 s of silence.

Mutation-checked rather than merely passing. Removing the rate limit fails 1 of the 7; removing the offline check fails 3 — including the last case above, which is the one I would most expect to get wrong.

`black --check` and `flake8` clean. Locally on macOS `pytest` reports 18 failures and 28 errors both with and without this branch — pre-existing and unrelated; this adds 7 passing tests and changes neither count.

### Not verified against hardware

I have not reproduced a stalled connection on a bench. The suppression and rate limiting are exercised by the tests above at the level of the decision, not of a real outage, so the behaviour during an actual disconnect would benefit from someone watching a real log through one.

